### PR TITLE
Do not create or update the GitHub commit status for the `whitespace` job

### DIFF
--- a/pipelines/main/misc/whitespace.yml
+++ b/pipelines/main/misc/whitespace.yml
@@ -17,8 +17,5 @@ steps:
           workspaces:
             - "/cache/repos:/cache/repos"
     timeout_in_minutes: 10
-    notify:
-      - github_commit_status:
-          context: "whitespace"
     commands: |
       make --output-sync -j$${JULIA_CPU_THREADS:?} check-whitespace


### PR DESCRIPTION
GitHub now has a "require a pull request before merging" branch protection setting. This allows us to prevent direct pushes to the `master` branch without needing to mark the `whitespace` check as a required status check. I have enabled the "require a pull request before merging" branch protection setting for the `master` branch of the `JuliaLang/julia` repository. Therefore, we no longer need to create or update the GitHub commit status for the `whitespace` job.

---

![Screen Shot 2022-02-12 at 4 49 31 AM](https://user-images.githubusercontent.com/5619885/153707400-f3404c9a-8a1f-4def-b692-1a6442ea13bd.png)