### PR TITLE
We must use `./` when referring to an external-buildkite filename

### DIFF
--- a/pipelines/main/0_webui.yml
+++ b/pipelines/main/0_webui.yml
@@ -10,7 +10,7 @@ steps:
           sandbox_capable: "true"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - staticfloat/cryptic#v2:
               # Our list of pipelines that should be launched (but don't require a signature)

--- a/pipelines/main/launch_signed_jobs.yml
+++ b/pipelines/main/launch_signed_jobs.yml
@@ -3,7 +3,7 @@ steps:
   - label: ":buildkite: :unlock: Launch signed pipelines"
     plugins:
       - JuliaCI/external-buildkite#v1:
-          version: ".buildkite-external-version"
+          version: "./.buildkite-external-version"
           repo_url: "https://github.com/JuliaCI/julia-buildkite"
     commands: |
       # Explicitly pass along the cryptic token to child pipelines

--- a/pipelines/main/launch_signed_jobs.yml.signature
+++ b/pipelines/main/launch_signed_jobs.yml.signature
@@ -1,1 +1,2 @@
-Salted__…üE—ŠÚô'èÛsœnm®~H¯SßuƒuÐê)÷àˆÔ¥°ùAýË‹ ¢ö¨D†÷ûùl‘­Ð<æ¸³(aÝ£¹„þ;Üðé¼‘¢}m¹ 5-Ä
+Salted__@¿$ƒóK:×-Ì!H8
+(¸µ3ŒE÷–ýòtzäunÝÙ	Ð—!‚ÐF/Ö+¡CI‘u¬V¼>9]5Òä³j(µÁWqkb¬äoY™û#Mw±Ò6Ž­

--- a/pipelines/main/launch_unsigned_builders.yml
+++ b/pipelines/main/launch_unsigned_builders.yml
@@ -18,7 +18,7 @@ steps:
       - label: ":buildkite: Launch misc. jobs"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/whitespace.yml
@@ -30,7 +30,7 @@ steps:
       - label: ":buildkite: Launch jobs"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           # Launch the miscellaneous jobs in alphabetical order.

--- a/pipelines/main/misc/doctest.yml
+++ b/pipelines/main/misc/doctest.yml
@@ -5,7 +5,7 @@ steps:
         key: doctest
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/misc/embedding.yml
+++ b/pipelines/main/misc/embedding.yml
@@ -5,7 +5,7 @@ steps:
         key: "embedding"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/misc/llvmpasses.yml
+++ b/pipelines/main/misc/llvmpasses.yml
@@ -5,7 +5,7 @@ steps:
         key: "analyzegc"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/misc/sanitizers.yml
+++ b/pipelines/main/misc/sanitizers.yml
@@ -5,7 +5,7 @@ steps:
       key: "asan"
       plugins:
         - JuliaCI/external-buildkite#v1:
-            version: ".buildkite-external-version"
+            version: "./.buildkite-external-version"
             repo_url: "https://github.com/JuliaCI/julia-buildkite"
         - JuliaCI/julia#v1:
             # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/misc/whitespace.yml
+++ b/pipelines/main/misc/whitespace.yml
@@ -5,7 +5,7 @@ steps:
         key: "whitespace"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -5,7 +5,7 @@ steps:
         key: "build_${TRIPLET?}"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -7,7 +7,7 @@ steps:
           - "build_${TRIPLET?}"
         plugins:
           - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
           - JuliaCI/julia#v1:
               # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -8,7 +8,7 @@ steps:
       - "test_${TRIPLET?}"
     plugins:
       - JuliaCI/external-buildkite#v1:
-              version: ".buildkite-external-version"
+              version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
       - JuliaCI/julia#v1:
           # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/pipelines/scheduled/coverage/coverage_linux64.yml.signature
+++ b/pipelines/scheduled/coverage/coverage_linux64.yml.signature
@@ -1,1 +1,1 @@
-Salted__ŠïË•, ê#ŠWâ3æ8O	%÷UØF]_Ch1'»bBöMD#ïÅ%7=)Bw+™xü.bìmdud¡"Ýg]d8{i^°ó=dÿg…ç7
+Salted__5DJ»Ë÷m{O¬…bª’GíW°ðn	kÊ->GÏm,áæ:n&=ŒÏ75µn2gKh~ä§¼(ôâùVYYõµ+‹–¿Ø±ÞÈÐ-ÛÚ‹˜Þ6Qú


### PR DESCRIPTION
This was documented, and summarily ignored by me as I added these plugin
stanzas.  We don't hit this on our own self-CI, because we override
these values.