### PR TITLE
Try giving `rr` a maximum of 16 cores

### DIFF
--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -55,16 +55,18 @@ end
 
 @info "We will run the command under rr"
 
+const MAX_SUPPORTED_RR_NUM_CORES = 16
+
 const build_number                      = get_from_env("BUILDKITE_BUILD_NUMBER")
 const job_name                          = get_from_env("BUILDKITE_STEP_KEY")
 const commit_full                       = get_from_env("BUILDKITE_COMMIT")
 const commit_short                      = first(commit_full, 10)
 const JULIA_TEST_RR_TIMEOUT_MINUTES     = get(ENV,  "JULIA_TEST_RR_TIMEOUT_MINUTES", "120")
 const timeout_minutes                   = parse(Int, JULIA_TEST_RR_TIMEOUT_MINUTES)
-const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "16")
+const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "$(MAX_SUPPORTED_RR_NUM_CORES)")
 const julia_test_num_cores_int          = parse(Int, JULIA_TEST_NUM_CORES)
 const num_cores = min(
-    16,
+    MAX_SUPPORTED_RR_NUM_CORES,
     Sys.CPU_THREADS,
     julia_test_num_cores_int + 1,
 )

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -61,7 +61,7 @@ const commit_full                       = get_from_env("BUILDKITE_COMMIT")
 const commit_short                      = first(commit_full, 10)
 const JULIA_TEST_RR_TIMEOUT_MINUTES     = get(ENV,  "JULIA_TEST_RR_TIMEOUT_MINUTES", "120")
 const timeout_minutes                   = parse(Int, JULIA_TEST_RR_TIMEOUT_MINUTES)
-const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "8")
+const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "16")
 const julia_test_num_cores_int          = parse(Int, JULIA_TEST_NUM_CORES)
 const num_cores = min(
     16,

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -55,8 +55,6 @@ end
 
 @info "We will run the command under rr"
 
-const MAX_SUPPORTED_RR_NUM_CORES = 16
-
 const build_number                      = get_from_env("BUILDKITE_BUILD_NUMBER")
 const job_name                          = get_from_env("BUILDKITE_STEP_KEY")
 const commit_full                       = get_from_env("BUILDKITE_COMMIT")
@@ -66,7 +64,8 @@ const timeout_minutes                   = parse(Int, JULIA_TEST_RR_TIMEOUT_MINUT
 const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "$(Sys.CPU_THREADS)")
 const julia_test_num_cores_int          = parse(Int, JULIA_TEST_NUM_CORES)
 const num_cores = min(
-    MAX_SUPPORTED_RR_NUM_CORES,
+    # We'll limit `rr` to a maximum of 16 cores.
+    16,
     Sys.CPU_THREADS,
     julia_test_num_cores_int + 1,
 )

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -64,7 +64,7 @@ const timeout_minutes                   = parse(Int, JULIA_TEST_RR_TIMEOUT_MINUT
 const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "8")
 const julia_test_num_cores_int          = parse(Int, JULIA_TEST_NUM_CORES)
 const num_cores = min(
-    8,
+    16,
     Sys.CPU_THREADS,
     julia_test_num_cores_int + 1,
 )

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -63,7 +63,7 @@ const commit_full                       = get_from_env("BUILDKITE_COMMIT")
 const commit_short                      = first(commit_full, 10)
 const JULIA_TEST_RR_TIMEOUT_MINUTES     = get(ENV,  "JULIA_TEST_RR_TIMEOUT_MINUTES", "120")
 const timeout_minutes                   = parse(Int, JULIA_TEST_RR_TIMEOUT_MINUTES)
-const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "$(MAX_SUPPORTED_RR_NUM_CORES)")
+const JULIA_TEST_NUM_CORES              = get(ENV,  "JULIA_TEST_NUM_CORES", "$(Sys.CPU_THREADS)")
 const julia_test_num_cores_int          = parse(Int, JULIA_TEST_NUM_CORES)
 const num_cores = min(
     MAX_SUPPORTED_RR_NUM_CORES,


### PR DESCRIPTION
Let's just see what happens