### PR TITLE
Modify the existing `rr` tester job to use an assert build of Julia (instead of a regular build)

### DIFF
--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -1,11 +1,11 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH_ROOTFS    MAKE_FLAGS     TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
-# linux    i686-linux-gnu          .             i686           .              .             v4.8          b6dffc772ab4c2cd7fd4f83459308f6f0d89b957
-linux      x86_64-linux-gnu        .             x86_64         .              .             v5.1          f689ba6acab6c13a3da4ff62e3445dd61c3b5ab0
-# linux    aarch64-linux-gnu       .             aarch64        .              .             ----          ----------------------------------------
-# linux    armv7l-linux-gnueabihf  .             armv7l         .              .             ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu   .             powerpc64le    .              .             ----          ----------------------------------------
-# musl     x86_64-linux-musl       .             x86_64         .              .             v4.8          d13a47c87c38005bd5d97132e51789cafd852f90
-
+# OS       TRIPLET                   ALLOW_FAIL    ARCH_ROOTFS    MAKE_FLAGS                              TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
+# linux    i686-linux-gnu            .             i686           .                                       .             v4.8          b6dffc772ab4c2cd7fd4f83459308f6f0d89b957
+linux      x86_64-linux-gnu          .             x86_64         .                                       .             v5.1          f689ba6acab6c13a3da4ff62e3445dd61c3b5ab0
+linux      x86_64-linux-gnuassert    .             x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1    .             v5.1          f689ba6acab6c13a3da4ff62e3445dd61c3b5ab0
+# linux    aarch64-linux-gnu         .             aarch64        .                                       .             ----          ----------------------------------------
+# linux    armv7l-linux-gnueabihf    .             armv7l         .                                       .             ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu     .             powerpc64le    .                                       .             ----          ----------------------------------------
+# musl     x86_64-linux-musl         .             x86_64         .                                       .             v4.8          d13a47c87c38005bd5d97132e51789cafd852f90
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -28,7 +28,7 @@ steps:
           ARCH="$${ARCH??}" source .buildkite/utilities/export_julia_cpu_target.sh
 
           echo "--- Build Julia"
-          export MAKE_FLAGS_SPACE_SEP=`echo "${MAKE_FLAGS:?}" | tr "," " "`
+          export MAKE_FLAGS_SPACE_SEP=`echo "${MAKE_FLAGS?}" | tr "," " "`
           echo "Make flags: $${MAKE_FLAGS_SPACE_SEP?}"
           make --output-sync -j 8 $${MAKE_FLAGS_SPACE_SEP?}
 

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -28,7 +28,9 @@ steps:
           ARCH="$${ARCH??}" source .buildkite/utilities/export_julia_cpu_target.sh
 
           echo "--- Build Julia"
-          make --output-sync -j 8 ${MAKE_FLAGS?}
+          export MAKE_FLAGS_SPACE_SEP=`echo "${MAKE_FLAGS:?}" | tr "," " "`
+          echo "Make flags: $${MAKE_FLAGS_SPACE_SEP:?}"
+          make --output-sync -j 8 $${MAKE_FLAGS_SPACE_SEP:?}
 
           echo "--- Check that the working directory is clean"
           if [ -z "$(git status --short)" ]; then
@@ -44,7 +46,7 @@ steps:
           ./julia -e 'using InteractiveUtils; InteractiveUtils.versioninfo()'
 
           echo "--- Create build artifacts"
-          make --output-sync -j 8 binary-dist ${MAKE_FLAGS?}
+          make --output-sync -j 8 binary-dist ${MAKE_FLAGS_SPACE_SEP?}
 
           # Rename the build artifact in case we want to name it differently, as is the case on `musl`.
           if [[ "$${JULIA_BINARYDIST_FILENAME}" != "$${UPLOAD_FILENAME}" ]]; then

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -46,7 +46,7 @@ steps:
           ./julia -e 'using InteractiveUtils; InteractiveUtils.versioninfo()'
 
           echo "--- Create build artifacts"
-          make --output-sync -j 8 binary-dist ${MAKE_FLAGS_SPACE_SEP?}
+          make --output-sync -j 8 binary-dist $${MAKE_FLAGS_SPACE_SEP?}
 
           # Rename the build artifact in case we want to name it differently, as is the case on `musl`.
           if [[ "$${JULIA_BINARYDIST_FILENAME}" != "$${UPLOAD_FILENAME}" ]]; then

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -29,8 +29,8 @@ steps:
 
           echo "--- Build Julia"
           export MAKE_FLAGS_SPACE_SEP=`echo "${MAKE_FLAGS:?}" | tr "," " "`
-          echo "Make flags: $${MAKE_FLAGS_SPACE_SEP:?}"
-          make --output-sync -j 8 $${MAKE_FLAGS_SPACE_SEP:?}
+          echo "Make flags: $${MAKE_FLAGS_SPACE_SEP?}"
+          make --output-sync -j 8 $${MAKE_FLAGS_SPACE_SEP?}
 
           echo "--- Check that the working directory is clean"
           if [ -z "$(git status --short)" ]; then

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,14 +1,12 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-# linux    686-linux-gnu           .             i686           .          .        v4.8          b6dffc772ab4c2cd7fd4f83459308f6f0d89b957
-linux      x86_64-linux-gnu        .             x86_64         .          .        v4.8          2a058481b567f0e91b9aa3ce4ad4f09e6419355a
-linux      x86_64-linux-gnu        .             x86_64         150        rr       v4.8          2a058481b567f0e91b9aa3ce4ad4f09e6419355a
+# OS       TRIPLET                   ALLOW_FAIL    ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+# linux    686-linux-gnu             .             i686           .          .        v4.8          b6dffc772ab4c2cd7fd4f83459308f6f0d89b957
+linux      x86_64-linux-gnu          .             x86_64         .          .        v4.8          2a058481b567f0e91b9aa3ce4ad4f09e6419355a
+linux      x86_64-linux-gnuassert    .             x86_64         360        rr       v4.8          2a058481b567f0e91b9aa3ce4ad4f09e6419355a
+# linux    aarch64-linux-gnu         true          aarch64        .          .        ----          ----------------------------------------
+# linux    armv7l-linux-gnueabihf    true          armv7l         .          .        ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu     true          powerpc64le    .          .        ----          ----------------------------------------
 
-# linux    aarch64-linux-gnu       true          aarch64        .          .        ----          ----------------------------------------
-# linux    armv7l-linux-gnueabihf  true          armv7l         .          .        ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu   true          powerpc64le    .          .        ----          ----------------------------------------
-
-# musl     x86_64-linux-musl       true          x86_64         .          .        v4.8          d13a47c87c38005bd5d97132e51789cafd852f90
-
+# musl     x86_64-linux-musl         true          x86_64         .          .        v4.8          d13a47c87c38005bd5d97132e51789cafd852f90
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/utilities/arches_env.sh
+++ b/utilities/arches_env.sh
@@ -15,7 +15,7 @@ fi
 
 enforce_sanitized() {
     for value in "$@"; do
-        if ! [[ "${value}" =~ ^[a-zA-Z0-9_\.[:space:]-]*$ ]]; then
+        if ! [[ "${value}" =~ ^[a-zA-Z0-9_\.[:space:]=,-]*$ ]]; then
             echo "Arches file '${ARCHES_FILE}' contains value '${value}' with non-alphanumeric characters; refusing to parse!" >&2
             exit 1
         fi

--- a/utilities/calc_version_envs.sh
+++ b/utilities/calc_version_envs.sh
@@ -12,6 +12,9 @@ case "${TRIPLET}" in
     *-mingw*)
         OS="windows"
         ;;
+    *-gnuassert)
+        OS="linuxassert"
+        ;;
     *-gnu*)
         OS="linux"
         ;;


### PR DESCRIPTION
Fixes #40

## Description

This PR:
1. Adds a new build job ("packager") that builds Julia with `FORCE_ASSERTIONS=1` and `LLVM_ASSERTIONS=1`.
2. Modifies the existing `rr` tester job so that it uses the assert build instead of a regular build.

## Timeouts

The combination of `rr` and an assert build is going to be very slow. Therefore, this PR increases the timeouts for the `rr` tests.

| Environment variable                     | Value   | Δ            |
| ---------------------------------------- | ------- | ------------ |
| `JULIA_TEST_RR_RUNTESTS_TIMEOUT_MINUTES` | 4 hours |              |
| `JULIA_TEST_RR_CLEANUP_TIMEOUT_MINUTES`  | 5 hours | + 60 minutes |
| `BUILDKITE_TIMEOUT`                      | 6 hours | + 60 minutes |

1. `JULIA_TEST_RR_RUNTESTS_TIMEOUT_MINUTES`: This is the amount of time that `Base.runtests("all")` gets. If this timeout is exceeded, we try to kill the `rr` process with `SIGTERM`.
2. `JULIA_TEST_RR_CLEANUP_TIMEOUT_MINUTES`: After we try to kill the `rr` process with `SIGTERM`, we wait some additional amount of time, corresponding to the `Δ` column in the `JULIA_TEST_RR_TIMEOUT_MINUTES_AFTER_CLEANUP` row. This period of time includes the time for `rr` to cleanup and exit; it also includes the time to upload the `rr` traces as Buildkite artifacts. If `rr` fails to cleanup and upload within this `Δ` amount of time, we kill the `rr` process with `SIGKILL`.
3. `BUILDKITE_TIMEOUT`: after we kill the `rr` process with `SIGKILL`, we should always see the job end immediately. So this additional `Δ` should never actually be used, unless something is going very wrong.