### PR TITLE
Do not upload assert builds to S3

### DIFF
--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -4,6 +4,7 @@ steps:
     # We only upload to S3 if all of the following are true:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
+    # 3. This is not an assert build.
     if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/))
     depends_on:
       # Wait for the builder to finish
@@ -34,6 +35,16 @@ steps:
             - .buildkite/secrets/tarball_signing.gpg
     timeout_in_minutes: ${TIMEOUT?}
     commands: |
+      echo "--- Check if this is an assert build"
+      # If this is an assert build, exit immediately.
+      # We assume that this is an assert build if and only if the TRIPLET contains
+      # the substring "assert".
+      if [[ "${TRIPLET?}" == *"assert"* ]]; then
+        echo "This is an assert build, so we will not upload it to S3."
+        echo "Exiting now..."
+        exit 0
+      fi
+
       # First, get things like `LONG_COMMIT` and `SHORT_COMMIT`, etc...
       TRIPLET="${TRIPLET?}" source .buildkite/utilities/calc_version_envs.sh
 


### PR DESCRIPTION
This is kind of a hacky solution, but it fixes the problem short-term, and then we can come up with a better long-term solution.