### PR TITLE
S3 upload: only upload if the pipeline is `julia-master` or `julia-release-*`

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -22,3 +22,6 @@ fi
 if ! buildkite-agent meta-data exists BUILDKITE_JULIA_VERSION; then
     buildkite-agent meta-data set BUILDKITE_JULIA_VERSION "$(git rev-parse HEAD)"
 fi
+
+# Export S3_BUCKET_PREFIX, to force our CI to upload to a different prefix than the actual CI pipeline would.
+export S3_BUCKET_PREFIX="ephemeral/bin"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -1,10 +1,8 @@
 steps:
   - label: ":linux: upload ${TRIPLET?}"
     key:   "upload_${TRIPLET?}"
-    # We only upload to S3 if all of the following are true:
-    # 1. This is not a pull request build.
-    # 2. The branch is `master` or `release-*`.
-    if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/))
+    # We only upload to S3 if the branch is `master` or `release-*`.
+    if: ((build.branch == "master") || (build.branch =~ /^release-/))
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/utilities/calc_version_envs.sh
+++ b/utilities/calc_version_envs.sh
@@ -53,29 +53,33 @@ JULIA_BINARYDIST_FILENAME="$(make print-JULIA_BINARYDIST_FILENAME | cut -c27- | 
 JULIA_INSTALL_DIR="julia-${TAR_VERSION}"
 JULIA_BINARY="${JULIA_INSTALL_DIR}/bin/julia"
 
+# By default, we upload to `julialangnightlies/bin`, but we allow this to be overridden
+S3_BUCKET="${S3_BUCKET:-julialangnightlies}"
+S3_BUCKET_PREFIX="${S3_BUCKET_PREFIX:-bin}"
+
 # We generally upload to multiple upload targets
 UPLOAD_TARGETS=(
     # First, we have the canonical fully-specified upload target
-    "julialangnightlies/bin/${OS?}/${ARCH?}/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}-${ARCH?}.tar.gz"
+    "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/${ARCH?}/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}-${ARCH?}.tar.gz"
 
     # Next, we have the "majmin/latest" upload target
-    "julialangnightlies/bin/${OS?}/${ARCH?}/${MAJMIN?}/julia-latest-${OS?}-${ARCH?}.tar.gz"
+    "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/${ARCH?}/${MAJMIN?}/julia-latest-${OS?}-${ARCH?}.tar.gz"
     
     # And then the general "latest" upload target
-    "julialangnightlies/bin/${OS?}/${ARCH?}/julia-latest-${OS?}-${ARCH?}.tar.gz"
+    "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/${ARCH?}/julia-latest-${OS?}-${ARCH?}.tar.gz"
 )
 UPLOAD_FILENAME="julia-${TAR_VERSION?}-${OS?}-${ARCH?}.tar.gz"
 
 # Finally, for compatibility, we keep on uploading x86_64 and i686 targets to folders called `x64`
 # and `x86`, and ending in `-linux64` and `-linux32`, although I would very much like to stop doing that.
 if [[ "${ARCH}" == "x86_64" ]]; then
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x64/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}64.tar.gz" )
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x64/${MAJMIN?}/julia-latest-${OS?}64.tar.gz" )
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x64/julia-latest-${OS?}64.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x64/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}64.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x64/${MAJMIN?}/julia-latest-${OS?}64.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x64/julia-latest-${OS?}64.tar.gz" )
 elif [[ "${ARCH}" == "i686" ]]; then
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x86/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}32.tar.gz" )
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x86/${MAJMIN?}/julia-latest-${OS?}32.tar.gz" )
-    UPLOAD_TARGETS+=( "julialangnightlies/bin/${OS?}/x86/julia-latest-${OS?}32.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x86/${MAJMIN?}/julia-${TAR_VERSION?}-${OS?}32.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x86/${MAJMIN?}/julia-latest-${OS?}32.tar.gz" )
+    UPLOAD_TARGETS+=( "${S3_BUCKET}/${S3_BUCKET_PREFIX}/${OS?}/x86/julia-latest-${OS?}32.tar.gz" )
 fi
 
 echo "--- Print the full and short commit hashes"


### PR DESCRIPTION
We have a variety of pipelines, including:

| Pipeline slug            | URL                                                    |
| ------------------------ | ------------------------------------------------------ |
| `julia-buildkite`        | https://buildkite.com/julialang/julia-buildkite        |
| `julia-master`           | https://buildkite.com/julialang/julia-master           |
| `julia-master-scheduled` | https://buildkite.com/julialang/julia-master-scheduled | 
| `julia-release-1-dot-6`  | https://buildkite.com/julialang/julia-release-1-dot-6  | 
| `julia-release-1-dot-7`  | https://buildkite.com/julialang/julia-release-1-dot-7  |
| `julia-release-1-dot-8`  | https://buildkite.com/julialang/julia-release-1-dot-8  |

We don't want all of those pipelines to be uploading to S3, only some of them. So this PR adds conditional statements based on the pipeline slug.