### PR TITLE
Simplify the logic for "don't upload assert builds to S3"

### DIFF
--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,7 +5,8 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && build.env("BUILDKITE_STEP_KEY") =~ /assert/
+    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_STEP_KEY") =~ /assert/) # TODO: uncomment this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env("BUILDKITE_STEP_KEY") =~ /assert/) # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -6,7 +6,7 @@ steps:
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
     # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("TRIPLET") !~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env("TRIPLET") !~ /assert/) # TODO: delete this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env("TRIPLET") == "x86_64-linux-gnu") # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,7 +5,7 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/))
+    if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && build.env("BUILDKITE_STEP_KEY") =~ /assert/
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"
@@ -36,16 +36,6 @@ steps:
             - .buildkite/secrets/tarball_signing.gpg
     timeout_in_minutes: ${TIMEOUT?}
     commands: |
-      echo "--- Check if this is an assert build"
-      # If this is an assert build, exit immediately.
-      # We assume that this is an assert build if and only if the TRIPLET contains
-      # the substring "assert".
-      if [[ "${TRIPLET?}" == *"assert"* ]]; then
-        echo "This is an assert build, so we will not upload it to S3."
-        echo "Exiting now..."
-        exit 0
-      fi
-
       # First, get things like `LONG_COMMIT` and `SHORT_COMMIT`, etc...
       TRIPLET="${TRIPLET?}" source .buildkite/utilities/calc_version_envs.sh
 

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -6,7 +6,7 @@ steps:
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
     # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("TRIPLET") !~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env("TRIPLET") == "x86_64-linux-gnu") # TODO: delete this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env(build.env("TRIPLET")) == "x86_64-linux-gnu") # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,8 +5,8 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_LABEL") !~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env("BUILDKITE_LABEL") !~ /assert/) # TODO: delete this line before merging the PR
+    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("TRIPLET") !~ /assert/) # TODO: uncomment this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env("TRIPLET") !~ /assert/) # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,8 +5,8 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("TRIPLET") !~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env(build.env("TRIPLET")) == "x86_64-linux-gnu") # TODO: delete this line before merging the PR
+    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env('TRIPLET') !~ /assert/) # TODO: uncomment this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env('HELLO_WORLD') == "x86_64-linux-gnu") # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,8 +5,8 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_STEP_KEY") !~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env("BUILDKITE_STEP_KEY") !~ /assert/) # TODO: delete this line before merging the PR
+    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_LABEL") !~ /assert/) # TODO: uncomment this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env("BUILDKITE_LABEL") !~ /assert/) # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -5,8 +5,8 @@ steps:
     # 1. This is not a pull request build.
     # 2. The branch is `master` or `release-*`.
     # 3. This is not an assert build.
-    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_STEP_KEY") =~ /assert/) # TODO: uncomment this line before merging the PR
-    if: (build.pull_request.id != null) && (build.env("BUILDKITE_STEP_KEY") =~ /assert/) # TODO: delete this line before merging the PR
+    # if: (build.pull_request.id == null) && ((build.branch == "master") || (build.branch =~ /^release-/)) && (build.env("BUILDKITE_STEP_KEY") !~ /assert/) # TODO: uncomment this line before merging the PR
+    if: (build.pull_request.id != null) && (build.env("BUILDKITE_STEP_KEY") !~ /assert/) # TODO: delete this line before merging the PR
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"


### PR DESCRIPTION
I think this is a better way to implement the "don't upload assert builds to S3" logic, because it uses the Buildkite `if` conditional.