### PR TITLE
`.gitignore`: add some other common names for the private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # Ignore the unencrypted repo_key
 repo_key
+repo.key
 
 # Ignore any agent keys (public or private) we have stored
 agent_key*
+agent.key*


### PR DESCRIPTION
We have it as `repo.key`, etc. in the secrets manager.