### PR TITLE
Upload to the "ephemeral" S3 bucket on every PR to this repo (the `JuliaCI/julia-buildkite` repo)

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -23,5 +23,6 @@ if ! buildkite-agent meta-data exists BUILDKITE_JULIA_VERSION; then
     buildkite-agent meta-data set BUILDKITE_JULIA_VERSION "$(git rev-parse HEAD)"
 fi
 
-# Export S3_BUCKET_PREFIX, to force our CI to upload to a different prefix than the actual CI pipeline would.
-export S3_BUCKET_PREFIX="ephemeral/bin"
+# Export S3_BUCKET and S3_BUCKET_PREFIX, to force our CI to upload to a different S3 target than the actual CI pipeline would.
+export S3_BUCKET="julialang-ephemeral"
+export S3_BUCKET_PREFIX="julia-buildkite-uploads/bin"

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -1,8 +1,12 @@
 steps:
   - label: ":linux: upload ${TRIPLET?}"
     key:   "upload_${TRIPLET?}"
-    # We only upload to S3 if the branch is `master` or `release-*`.
-    if: (build.branch == "master") || (build.branch =~ /^release-/) || (build.tag =~ /^v/)
+    # We only upload to S3 if one of the following criteria are true:
+    # 1. The branch is `master`.
+    # 2. The branch is `release-*`.
+    # 3. The build is a tag build AND the tag is `v*`.
+    # 4. The pipeline is `julia-buildkite`.
+    if: (build.branch == "master") || (build.branch =~ /^release-/) || (build.tag =~ /^v/) || (pipeline.slug == "julia-buildkite")
     depends_on:
       # Wait for the builder to finish
       - "build_${TRIPLET?}"


### PR DESCRIPTION
The idea here is that a PR to this repo (the `JuliaCI/julia-buildkite` repo) has the potential to break the "upload to S3" job. We don't want to wait to find out about this breakage until after the PR is merged; we want to catch it on the PR CI.