### PR TITLE
Add one new Buildkite group (`Allow Fail`), but do not add a GitHub commit status for that group

### DIFF
--- a/pipelines/main/launch_unsigned_builders.yml
+++ b/pipelines/main/launch_unsigned_builders.yml
@@ -25,11 +25,13 @@ steps:
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           # Launch Linux build jobs
-          bash .buildkite/utilities/arches_pipeline_upload.sh \
+          GROUP="Build" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_linux.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
           # Launch macOS packaging jobs
-          bash .buildkite/utilities/arches_pipeline_upload.sh \
+          GROUP="Build" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_macos.arches \
               .buildkite/pipelines/main/platforms/build_macos.yml
         agents:
@@ -64,12 +66,47 @@ steps:
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           # Launch Linux test jobs
-          bash .buildkite/utilities/arches_pipeline_upload.sh \
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_linux.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml
           # Launch macOS test jobs
-          bash .buildkite/utilities/arches_pipeline_upload.sh \
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_macos.arches \
+              .buildkite/pipelines/main/platforms/test_macos.yml
+        agents:
+          queue: "julia"
+  - group: "Allow Fail"
+    steps:
+      - label: "Launch allowed-to-fail build jobs"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          # Launch Linux allowed-to-fail build jobs
+          GROUP="Allow Fail" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/build_linux.soft_fail.arches \
+              .buildkite/pipelines/main/platforms/build_linux.yml
+        agents:
+          queue: "julia"
+      - label: "Launch allowed-to-fail test jobs"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          # Launch Linux allowed-to-fail test jobs
+          GROUP="Allow Fail" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/test_linux.soft_fail.arches \
+              .buildkite/pipelines/main/platforms/test_linux.yml
+          # Launch macOS test jobs that are allowed to fail
+          GROUP="Allow Fail" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/test_macos.soft_fail.arches \
               .buildkite/pipelines/main/platforms/test_macos.yml
         agents:
           queue: "julia"

--- a/pipelines/main/launch_unsigned_builders.yml
+++ b/pipelines/main/launch_unsigned_builders.yml
@@ -26,11 +26,13 @@ steps:
         commands: |
           # Launch Linux build jobs
           GROUP="Build" \
+              ALLOW_FAIL="false" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_linux.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
           # Launch macOS packaging jobs
           GROUP="Build" \
+              ALLOW_FAIL="false" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_macos.arches \
               .buildkite/pipelines/main/platforms/build_macos.yml
@@ -67,11 +69,13 @@ steps:
         commands: |
           # Launch Linux test jobs
           GROUP="Test" \
+              ALLOW_FAIL="false" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_linux.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml
           # Launch macOS test jobs
           GROUP="Test" \
+              ALLOW_FAIL="false" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_macos.arches \
               .buildkite/pipelines/main/platforms/test_macos.yml
@@ -87,9 +91,11 @@ steps:
         commands: |
           # Launch Linux allowed-to-fail build jobs
           GROUP="Allow Fail" \
+              ALLOW_FAIL="true" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_linux.soft_fail.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
+          # Currently, we do not have any macOS allowed-to-fail test jobs
         agents:
           queue: "julia"
       - label: "Launch allowed-to-fail test jobs"
@@ -100,11 +106,13 @@ steps:
         commands: |
           # Launch Linux allowed-to-fail test jobs
           GROUP="Allow Fail" \
+              ALLOW_FAIL="true" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_linux.soft_fail.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml
-          # Launch macOS test jobs that are allowed to fail
+          # Launch macOS allowed-to-fail test jobs
           GROUP="Allow Fail" \
+              ALLOW_FAIL="true" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_macos.soft_fail.arches \
               .buildkite/pipelines/main/platforms/test_macos.yml

--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -3,12 +3,12 @@
 linux      x86_64-linux-gnu          .             x86_64         x86_64         CFLAGS=-Werror,CXXFLAGS=-Werror                                         .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
 linux      x86_64-linux-gnuassert    .             x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,CFLAGS=-Werror,CXXFLAGS=-Werror    .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
 # linux    aarch64-linux-gnu         .             aarch64        aarch64        .                                                                       .             ----          ----------------------------------------
-# linux    armv7l-linux-gnueabihf    .             armv7l         armv7l         .                                                                       .             ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu     .             powerpc64le    powerpc64le    .                                                                       .             ----          ----------------------------------------
 musl       x86_64-linux-musl         .             x86_64         x86_64         .                                                                       .             v5.8          dc23dbeb02f9b85c8c8c7991ee8cfcae8f4c809b
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
+
+#default GROUP build
 
 # Of course we do not allow jobs to fail typically
 #default ALLOW_FAIL false

--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -1,17 +1,12 @@
-# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    MAKE_FLAGS                              TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
-# linux    i686-linux-gnu            .             x86_64         i686           .                                                                       .             ----          ----------------------------------------
-linux      x86_64-linux-gnu          .             x86_64         x86_64         CFLAGS=-Werror,CXXFLAGS=-Werror                                         .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
-linux      x86_64-linux-gnuassert    .             x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,CFLAGS=-Werror,CXXFLAGS=-Werror    .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
-# linux    aarch64-linux-gnu         .             aarch64        aarch64        .                                                                       .             ----          ----------------------------------------
-musl       x86_64-linux-musl         .             x86_64         x86_64         .                                                                       .             v5.8          dc23dbeb02f9b85c8c8c7991ee8cfcae8f4c809b
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    MAKE_FLAGS                                                              TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
+# linux    i686-linux-gnu             x86_64         i686           .                                                                       .             ----          ----------------------------------------
+linux      x86_64-linux-gnu           x86_64         x86_64         CFLAGS=-Werror,CXXFLAGS=-Werror                                         .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
+linux      x86_64-linux-gnuassert     x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,CFLAGS=-Werror,CXXFLAGS=-Werror    .             v5.8          582b5d44bbc24d2a58ab609c5a520b3fd102e504
+# linux    aarch64-linux-gnu          aarch64        aarch64        .                                                                       .             ----          ----------------------------------------
+musl       x86_64-linux-musl          x86_64         x86_64         .                                                                       .             v5.8          dc23dbeb02f9b85c8c8c7991ee8cfcae8f4c809b
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-#default GROUP build
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -1,0 +1,12 @@
+# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    MAKE_FLAGS                              TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
+# linux    armv7l-linux-gnueabihf    true          armv7l         armv7l         .                                                                       .             ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu     true          powerpc64le    powerpc64le    .                                                                       .             ----          ----------------------------------------
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Of course we do not allow jobs to fail typically
+#default ALLOW_FAIL false
+
+# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
+#default TIMEOUT 90

--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -1,12 +1,9 @@
-# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    MAKE_FLAGS                              TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
-# linux    armv7l-linux-gnueabihf    true          armv7l         armv7l         .                                                                       .             ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu     true          powerpc64le    powerpc64le    .                                                                       .             ----          ----------------------------------------
+# OS       TRIPLET                   ARCH     ARCH_ROOTFS    MAKE_FLAGS    TIMEOUT     ROOTFS_TAG    ROOTFS_HASH
+# linux    armv7l-linux-gnueabihf    true     armv7l         armv7l         .          .             ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu     true     powerpc64le    powerpc64le    .          .             ----          ----------------------------------------
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Build"
+  - group: "${GROUP?}"
     steps:
       - label: ":linux: build ${TRIPLET?}"
         key: "build_${TRIPLET?}"

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -20,6 +20,7 @@ steps:
                 # Include `/cache/repos` so that our `git` version introspection works.
                 - "/cache/repos:/cache/repos"
         timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/build_julia.sh"
         agents:
           queue: "julia"

--- a/pipelines/main/platforms/build_macos.arches
+++ b/pipelines/main/platforms/build_macos.arches
@@ -1,13 +1,9 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
-macos      x86_64-apple-darwin     .             x86_64        .              .
-macos      aarch64-apple-darwin    .             aarch64       .              .
-
+# OS       TRIPLET                  ARCH          MAKE_FLAGS     TIMEOUT
+macos      x86_64-apple-darwin      x86_64        .              .
+macos      aarch64-apple-darwin     aarch64       .              .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/build_macos.yml
+++ b/pipelines/main/platforms/build_macos.yml
@@ -8,6 +8,7 @@ steps:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/build_julia.sh"
         agents:
           queue: "julia"

--- a/pipelines/main/platforms/build_macos.yml
+++ b/pipelines/main/platforms/build_macos.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Build"
+  - group: "${GROUP?}"
     steps:
       - label: ":macos: build ${TRIPLET?}"
         key: "build_${TRIPLET?}"

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,13 +1,10 @@
-# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-# linux    i686-linux-gnu            .             x86_64         i686           .          .        ----          ----------------------------------------
-linux      x86_64-linux-gnu          .             x86_64         x86_64         .          .        v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert    .             x86_64         x86_64         360        rr       v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+# linux    i686-linux-gnu             x86_64         i686           .          .        ----          ----------------------------------------
+linux      x86_64-linux-gnu           x86_64         x86_64         .          .        v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr       v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -2,11 +2,6 @@
 # linux    i686-linux-gnu            .             x86_64         i686           .          .        ----          ----------------------------------------
 linux      x86_64-linux-gnu          .             x86_64         x86_64         .          .        v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
 linux      x86_64-linux-gnuassert    .             x86_64         x86_64         360        rr       v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-# linux    aarch64-linux-gnu         true          aarch64        aarch64        .          .        ----          ----------------------------------------
-# linux    armv7l-linux-gnueabihf    true          armv7l         armv7l         .          .        ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu     true          powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
-
-musl       x86_64-linux-musl         true          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,14 +1,11 @@
-# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-# linux    aarch64-linux-gnu         true          aarch64        aarch64        .          .        ----          ----------------------------------------
-# linux    armv7l-linux-gnueabihf    true          armv7l         armv7l         .          .        ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu     true          powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
-musl       x86_64-linux-musl         true          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+# linux    aarch64-linux-gnu          aarch64        aarch64        .          .        ----          ----------------------------------------
+# linux    armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
+musl       x86_64-linux-musl          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,0 +1,14 @@
+# OS       TRIPLET                   ALLOW_FAIL    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+# linux    aarch64-linux-gnu         true          aarch64        aarch64        .          .        ----          ----------------------------------------
+# linux    armv7l-linux-gnueabihf    true          armv7l         armv7l         .          .        ----          ----------------------------------------
+# linux    powerpc64le-linux-gnu     true          powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
+musl       x86_64-linux-musl         true          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Of course we do not allow jobs to fail typically
+#default ALLOW_FAIL false
+
+# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
+#default TIMEOUT 90

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "${GROUP?}"
     steps:
       - label: ":linux: test ${TRIPLET?}${USE_RR-}"
         key: "test_${TRIPLET?}${USE_RR-}"

--- a/pipelines/main/platforms/test_macos.arches
+++ b/pipelines/main/platforms/test_macos.arches
@@ -1,11 +1,8 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
-macos      x86_64-apple-darwin     .             x86_64        .              .
+# OS       TRIPLET                 ARCH          MAKE_FLAGS     TIMEOUT
+macos      x86_64-apple-darwin     x86_64        .              .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/test_macos.arches
+++ b/pipelines/main/platforms/test_macos.arches
@@ -1,7 +1,5 @@
 # OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
 macos      x86_64-apple-darwin     .             x86_64        .              .
-macos      aarch64-apple-darwin    true             aarch64       .              .
-
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_macos.soft_fail.arches
+++ b/pipelines/main/platforms/test_macos.soft_fail.arches
@@ -1,11 +1,8 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
-macos      aarch64-apple-darwin    true          aarch64       .              .
+# OS       TRIPLET                  ARCH          MAKE_FLAGS     TIMEOUT
+macos      aarch64-apple-darwin     aarch64       .              .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/test_macos.soft_fail.arches
+++ b/pipelines/main/platforms/test_macos.soft_fail.arches
@@ -1,9 +1,11 @@
-# OS       TRIPLET              TIMEOUT
-linux      x86_64-linux-gnu     .
-musl       x86_64-linux-musl    .
+# OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
+macos      aarch64-apple-darwin    true          aarch64       .              .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Of course we do not allow jobs to fail typically
+#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90

--- a/pipelines/main/platforms/test_macos.yml
+++ b/pipelines/main/platforms/test_macos.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "${GROUP?}"
     steps:
       - label: ":macos: test ${TRIPLET?}"
         key: "test_${TRIPLET?}"

--- a/pipelines/main/platforms/upload_macos.arches
+++ b/pipelines/main/platforms/upload_macos.arches
@@ -1,13 +1,9 @@
-# OS       TRIPLET                 ALLOW_FAIL    ARCH          MAKE_FLAGS     TIMEOUT
-macos      x86_64-apple-darwin     .             x86_64        .              .
-macos      aarch64-apple-darwin    .             aarch64       .              .
-
+# OS       TRIPLET                     ARCH       TIMEOUT
+macos      x86_64-apple-darwin         x86_64     .
+macos      aarch64-apple-darwin        aarch64    .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
-
-# Of course we do not allow jobs to fail typically
-#default ALLOW_FAIL false
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90


### PR DESCRIPTION
This pull request adds one new Buildkite group:
1. `Allow Fail`

However, if desired, I can instead split that group up into two separate groups as such:
1. `Allow Fail (Build)`
2. `Allow Fail (Test)`

Fixes #47