### PR TITLE
Build for macOS with `-Werror`

### DIFF
--- a/pipelines/main/platforms/build_macos.arches
+++ b/pipelines/main/platforms/build_macos.arches
@@ -1,6 +1,6 @@
-# OS       TRIPLET                  ARCH          MAKE_FLAGS     TIMEOUT
-macos      x86_64-apple-darwin      x86_64        .              .
-macos      aarch64-apple-darwin     aarch64       .              .
+# OS       TRIPLET                  ARCH          MAKE_FLAGS                              TIMEOUT
+macos      x86_64-apple-darwin      x86_64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
+macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
With https://github.com/JuliaLang/julia/pull/44807 merged, we should now be able to build for macOS with `-Werror`, which is useful since here we use Clang, which tends to be stricter than GCC.