### PR TITLE
Temporarily move the Apple Silicon build to the "allow fail" category

### DIFF
--- a/pipelines/main/launch_unsigned_builders.yml
+++ b/pipelines/main/launch_unsigned_builders.yml
@@ -95,7 +95,12 @@ steps:
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/build_linux.soft_fail.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
-          # Currently, we do not have any macOS allowed-to-fail test jobs
+          # Launch macOS allowed-to-fail build jobs
+          GROUP="Allow Fail" \
+              ALLOW_FAIL="true" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/build_macos.soft_fail.arches \
+              .buildkite/pipelines/main/platforms/build_macos.yml
         agents:
           queue: "julia"
       - label: "Launch allowed-to-fail test jobs"

--- a/pipelines/main/platforms/build_macos.soft_fail.arches
+++ b/pipelines/main/platforms/build_macos.soft_fail.arches
@@ -1,8 +1,8 @@
 # OS       TRIPLET                  ARCH          MAKE_FLAGS                              TIMEOUT
+macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
 
 # TODO: move the Apple Silicon build out of the "allow fail" category once we have
 # more Apple Silicon machines.
-macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/build_macos.soft_fail.arches
+++ b/pipelines/main/platforms/build_macos.soft_fail.arches
@@ -1,5 +1,8 @@
 # OS       TRIPLET                  ARCH          MAKE_FLAGS                              TIMEOUT
-macos      x86_64-apple-darwin      x86_64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
+
+# TODO: move the Apple Silicon build out of the "allow fail" category once we have
+# more Apple Silicon machines.
+macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
I would have preferred to do https://github.com/JuliaCI/julia-buildkite/pull/new/dpa/apple-silicon-builder-allow-fail, but I can't figure out how to make `build.env("BUILDKITE_STEP_KEY")` work inside an `if:` statement.

So at least this will let manually cancel builds in the queue without turning the overall status red.