### PR TITLE
Add an `rr-net` tester that runs just the network-related tests under `rr`

### DIFF
--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,7 +1,8 @@
-# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-# linux    i686-linux-gnu             x86_64         i686           .          .        ----          ----------------------------------------
-linux      x86_64-linux-gnu           x86_64         x86_64         .          .        v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr       v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
+# linux    i686-linux-gnu             x86_64         i686           .          .          ----          ----------------------------------------
+linux      x86_64-linux-gnu           x86_64         x86_64         .          .          v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr-net     v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
Right now, the `rr` tester skips the network-related tests so that we can keep the trace size down.

I'm not particularly happy with the status quo. The tests in this list often fail non-deterministically. We often chalk it up to "network instability", but there could be genuine non-deterministic bugs that we are ignoring. If we have the `rr` traces for those failures, it at least gives us a better chance of fixing those bugs.

So this PR adds a new `rr-net` tester that runs just the network-related tests under `rr`. The existing `rr` tester is unmodified. This should ensure that our trace sizes stay below 5 GB.