### PR TITLE
Add `armv7l-linux-gnueabihf` builder, tester and uploader

### DIFF
--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -1,5 +1,5 @@
 # OS       TRIPLET                   ARCH           ARCH_ROOTFS    MAKE_FLAGS    TIMEOUT     ROOTFS_TAG    ROOTFS_HASH
-# linux    armv7l-linux-gnueabihf    armv7l         armv7l         .             .           ----          ----------------------------------------
+linux      armv7l-linux-gnueabihf    armv7l         armv7l         .             .           v5.14         fd4b53c846950c3de0fc08437b1193ace49d25e1
 # linux    powerpc64le-linux-gnu     powerpc64le    powerpc64le    .             .           ----          ----------------------------------------
 
 # These special lines allow us to embed default values for the columns above.

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,10 +1,13 @@
-# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
-linux      x86_64-linux-gnu           x86_64         x86_64         .          .          v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr-net     v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TESTS      TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
+linux      x86_64-linux-gnu           x86_64         x86_64         .           .          .          v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnuassert     x86_64         x86_64         .           360        rr         v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnuassert     x86_64         x86_64         .           360        rr-net     v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90
+
+# By default, we run all tests
+#default TESTS all

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,12 +1,15 @@
-# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-linux      i686-linux-gnu             x86_64         i686           .          .        v5.11         b40bb566fcb6502c2764c8d80ed5ffbe7cdcfaf3
-linux      aarch64-linux-gnu          aarch64        aarch64        .          .        v5.12         f7a9c2f23795d6fc0edb6068244ef6b18349bbcd
-# linux    armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
-# linux    powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
-musl       x86_64-linux-musl          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TESTS      TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+linux      i686-linux-gnu             x86_64         i686           .          .          .        v5.11         b40bb566fcb6502c2764c8d80ed5ffbe7cdcfaf3
+linux      aarch64-linux-gnu          aarch64        aarch64        .          .          .        v5.12         f7a9c2f23795d6fc0edb6068244ef6b18349bbcd
+linux      armv7l-linux-gnueabihf     armv7l         armv7l         compiler   .          .        v5.14         dd060bb0d73cde131e89972bdcafdd1794ae742f
+# linux    powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .          .        ----          ----------------------------------------
+musl       x86_64-linux-musl          x86_64         x86_64         .          .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
 # Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
 #default TIMEOUT 90
+
+# By default, we run all tests.
+#default TESTS all

--- a/pipelines/main/platforms/upload_linux.arches
+++ b/pipelines/main/platforms/upload_linux.arches
@@ -1,8 +1,9 @@
-# OS       TRIPLET               TIMEOUT
-linux      aarch64-linux-gnu     .
-linux      i686-linux-gnu        .
-linux      x86_64-linux-gnu      .
-musl       x86_64-linux-musl     .
+# OS       TRIPLET                 TIMEOUT
+linux      aarch64-linux-gnu       .
+linux      armv7l-linux-gnueabihf  .
+linux      i686-linux-gnu          .
+linux      x86_64-linux-gnu        .
+musl       x86_64-linux-musl       .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -50,23 +50,25 @@ if [[ "${ARCH}" == "i686" ]]; then
     # Assume that we only have 3.5GB available to a single process, and that a single
     # test can take up to 2GB of RSS.  This means that we should instruct the test
     # framework to restart any worker that comes into a test set with 1.5GB of RSS.
-    # export JULIA_TEST_MAXRSS_MB=1536
     export JULIA_TEST_MAXRSS_MB=1000
 fi
 
 # If we're running inside of `rr`, limit the number of threads
-if [[ "${USE_RR-}" == "rr" ]] || [[ "${USE_RR-}" == "rr-net" ]]; then
+if [[ -n "${USE_RR-}" ]]; then
     export JULIA_CMD_FOR_TESTS="${JULIA_BINARY} .buildkite/utilities/rr/rr_capture.jl ${JULIA_BINARY}"
     export NCORES_FOR_TESTS="parse(Int, ENV[\"JULIA_RRCAPTURE_NUM_CORES\"])"
     export JULIA_NUM_THREADS=1
 
-    # rr: all tests EXCEPT the network-related tests
-    # rr-net: ONLY the network-related tests
-    export NETWORK_RELATED_TESTS="Artifacts Downloads download LazyArtifacts LibGit2/online Pkg"
+    NETWORK_RELATED_TESTS="Artifacts Downloads download LazyArtifacts LibGit2/online Pkg"
     if [[ "${USE_RR-}" == "rr" ]]; then
-        export TESTS="all --ci --skip ${NETWORK_RELATED_TESTS:?}"
-    else
+        # rr: all tests EXCEPT the network-related tests
+        export TESTS="${TESTS} --ci --skip ${NETWORK_RELATED_TESTS:?}"
+    elif [[ "${USE_RR-}" == "rr-net" ]]; then
+        # rr-net: ONLY the network-related tests
         export TESTS="${NETWORK_RELATED_TESTS:?} --ci"
+    else
+        echo "ERROR: Unknown value for USE_RR: '${USE_RR-}'" >&2
+        exit 1
     fi
 else
     export JULIA_CMD_FOR_TESTS="${JULIA_BINARY}"
@@ -74,7 +76,7 @@ else
     export JULIA_NUM_THREADS="${JULIA_CPU_THREADS}"
 
     # Run all tests; `--ci` asserts that networking is available
-    export TESTS="all --ci"
+    export TESTS="${TESTS} --ci"
 fi
 
 echo "--- Print the list of test sets, and other useful environment variables"


### PR DESCRIPTION
Because testing on armv7l is painful, we run only a very small set of
tests, pending greater investment in armv7l infrastructure.