### PR TITLE
Automatically collect core dumps on linux when testing

### DIFF
--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,7 +1,7 @@
 # OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
-linux      x86_64-linux-gnu           x86_64         x86_64         .          .          v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
-linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr-net     v5.9          2212d69a3bc8a516ae8731ac20771d90d62206bc
+linux      x86_64-linux-gnu           x86_64         x86_64         .          .          v5.19         6d03dc546ae91b6173926aa3567d8e7d41010fc7
+linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v5.19         6d03dc546ae91b6173926aa3567d8e7d41010fc7
+linux      x86_64-linux-gnuassert     x86_64         x86_64         360        rr-net     v5.19         6d03dc546ae91b6173926aa3567d8e7d41010fc7
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.schedule.arches
+++ b/pipelines/main/platforms/test_linux.schedule.arches
@@ -1,5 +1,5 @@
 # OS       TRIPLET                       ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG     ROOTFS_HASH
-linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        .          v5.10          de7c87873a87ff4e90c5b97ad21bc80ef07c6577
+linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        .          v5.20          d4199ba65775a1b4ff74521ae77987076e4508fb
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,9 +1,9 @@
 # OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-linux      i686-linux-gnu             x86_64         i686           .          .        v5.11         b40bb566fcb6502c2764c8d80ed5ffbe7cdcfaf3
-linux      aarch64-linux-gnu          aarch64        aarch64        .          .        v5.12         f7a9c2f23795d6fc0edb6068244ef6b18349bbcd
+linux      i686-linux-gnu             x86_64         i686           .          .        v5.19         b1aa757351ed870e8445e9183da5e16b73036f8e
+linux      aarch64-linux-gnu          aarch64        aarch64        .          .        v5.19         3d386b368ac9a8d66524c37741c330dd9334ab66
 # linux    armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
 # linux    powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        ----          ----------------------------------------
-musl       x86_64-linux-musl          x86_64         x86_64         .          .        v5.9          417adcf6facf0933d496fa45a831a10632a7313f
+musl       x86_64-linux-musl          x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -7,6 +7,12 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
+          - JuliaCI/coreupload#sf/debugging:
+              core_pattern: "**/*.core"
+              compressor: "zstd"
+              disabled: "${USE_RR?}"
+              gdb_commands:
+                - "thread apply all bt"
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -85,5 +85,12 @@ echo "OPENBLAS_NUM_THREADS is:   ${OPENBLAS_NUM_THREADS:?}"
 echo "TESTS is:                  ${TESTS:?}"
 echo "USE_RR is:                 ${USE_RR-}"
 
+# Show our core dump file pattern and size limit if we're going to be recording them
+if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == "linux" || "${OS}" == "musl" ]]; then
+    ulimit -c unlimited
+    echo "Core dump pattern:         $(cat /proc/sys/kernel/core_pattern)"
+    echo "Core dump size limit:      $(ulimit -c)"
+fi
+
 echo "--- Run the Julia test suite"
 ${JULIA_CMD_FOR_TESTS:?} -e "Base.runtests(\"${TESTS:?}\"; ncores = ${NCORES_FOR_TESTS:?})"


### PR DESCRIPTION
When running Julia tests, segfaults can be difficult to find and
reproduce.  This adds automatic collection, inspection. compression and
uploading of core dump files to all linux testers.  It works by enabling
core dumps through `ulimit`, relying on our sandbox workers setting up a
good default core dump pattern [0], and then compressing the core dumps
with `zstd` before uploading to buildkite's artifact storage.  The
compression requires a tester rootfs that contains the `zstd` binaries,
which are available since rootfs release v5.17 [1].

We also stick in a few automatic `gdb` commands to give common debugging
output to allow developers to rapidly check common requests within the
web UI of buildkite itself.

[0] https://github.com/JuliaCI/sandboxed-buildkite-agent/commit/d64cacf719c5e20f4fc9abd50264459e0f4aefdf#diff-bdb8ed73fa1e3069f9f4eb7bf82cd431b578a6f462897ee8f73a4f6e3aacba9aR5
[1] https://github.com/JuliaCI/rootfs-images/commit/bdaf127c9b3bdecdbf7799dc2cfca2384bea5166