### PR TITLE
Add consistent timeout to all builds

### DIFF
--- a/pipelines/main/coverage/coverage.yml.signature
+++ b/pipelines/main/coverage/coverage.yml.signature
@@ -1,1 +1,2 @@
-Salted__krõN²drM­kN?ñpš	eü™rY“®§^õóðO£†ríŒÇ[C‘-T?:@ÞàzÞµ„|ŠÃ¢”„ƒì«bäÕŸŠî¡ÕªÍÑV!€›Çß¡‹Ÿm
+Salted__!gÏZÑãáØ%¤Ë`}*¿5ÙâÓá0îWœélž'ÿð£
+m÷åK¨œs—†¥ãYñÛå—õÂ§â% ë:B‡ô48WZY\;-üL1Jsü¦»ŽÂï²Äs

--- a/pipelines/main/launch_signed_jobs.yml.signature
+++ b/pipelines/main/launch_signed_jobs.yml.signature
@@ -1,1 +1,1 @@
-Salted__×;þô·a¨1"/¨›ÂšÐ‚9Nþ:¢AhrëéŠ¼â6Jéšeþ¡Ÿw!ôÀºôçüÚ³ÞyHïÄàðAc$U·4u-eO.óŠÓÎ#Ža9&
+Salted__üµ´…8få·Ý´ä1·ý¡…›z¿=zlÃ“ˆïr ³›HàÔ£³Dó/°´e@’z­žÅ.Ô-.#U–¯*ØùIü:€Ï¬mÒgÞÞ€hœ‘¾84âÀ~¡

--- a/pipelines/main/launch_upload_jobs.yml.signature
+++ b/pipelines/main/launch_upload_jobs.yml.signature
@@ -1,4 +1,2 @@
-Salted__Òæ»ìÞ˜+Õ1R©•7ÂL­
-¦ÿþ?¥Èûz;áI
-ñâŠÀÆZ>É
-ð˜ùÛ‡Û›wåÚ¯kX¿¥¸ÑT…÷†‚4í††ˆYTÁÄJ¦4õ·nÑ‚ŒÅƒ
+Salted__oÁÛìî¸‹‚’Ètà2dWVþk™zŽ`‹Xvˆ ‡pßÉ×íÔ¢M
+	«wCHK‚°„ø4PR}Ö!Lü§ÎPm«®é…¥=t_0"ŸÕVVš§È

--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -8,5 +8,5 @@ musl       x86_64-linux-musl          x86_64         x86_64         JL_CFLAGS=-W
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Builds should generally finish in much less time than this, but from-source builds can take longer
+#default TIMEOUT 80

--- a/pipelines/main/platforms/build_linux.schedule.arches
+++ b/pipelines/main/platforms/build_linux.schedule.arches
@@ -4,5 +4,5 @@ linux      x86_64-linux-gnusrcassert     x86_64         x86_64         USE_BINAR
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Builds should generally finish in much less time than this, but from-source builds can take longer
+#default TIMEOUT 80

--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -5,5 +5,5 @@
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Builds should generally finish in much less time than this, but from-source builds can take longer
+#default TIMEOUT 80

--- a/pipelines/main/platforms/build_macos.arches
+++ b/pipelines/main/platforms/build_macos.arches
@@ -4,5 +4,5 @@ macos      x86_64-apple-darwin      x86_64        JL_CFLAGS=-Werror,JL_CXXFLAGS=
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Builds should generally finish in much less time than this, but from-source builds can take longer
+#default TIMEOUT 80

--- a/pipelines/main/platforms/build_macos.soft_fail.arches
+++ b/pipelines/main/platforms/build_macos.soft_fail.arches
@@ -7,5 +7,5 @@ macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Builds should generally finish in much less time than this, but from-source builds can take longer
+#default TIMEOUT 80

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -6,5 +6,7 @@ linux      x86_64-linux-gnuassert     x86_64         x86_64         360        r
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/test_linux.schedule.arches
+++ b/pipelines/main/platforms/test_linux.schedule.arches
@@ -4,5 +4,7 @@ linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150      
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/test_linux.schedule.arches
+++ b/pipelines/main/platforms/test_linux.schedule.arches
@@ -1,5 +1,5 @@
 # OS       TRIPLET                       ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG     ROOTFS_HASH
-linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        .          v5.20          d4199ba65775a1b4ff74521ae77987076e4508fb
+linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        .          v5.21          e3fcf9b97c8f37f8de308214e377d99ad2071772
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.schedule.yml
+++ b/pipelines/main/platforms/test_linux.schedule.yml
@@ -7,6 +7,13 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
+          - JuliaCI/coreupload#v1:
+              core_pattern: "**/*.core"
+              compressor: "zstd"
+              disabled: "${USE_RR?}"
+              create_bundle: "true"
+              gdb_commands:
+                - "thread apply all bt"
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -8,5 +8,7 @@ musl       x86_64-linux-musl          x86_64         x86_64         .          .
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -7,10 +7,11 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
-          - JuliaCI/coreupload#sf/debugging:
+          - JuliaCI/coreupload#v1:
               core_pattern: "**/*.core"
               compressor: "zstd"
               disabled: "${USE_RR?}"
+              create_bundle: "true"
               gdb_commands:
                 - "thread apply all bt"
           - JuliaCI/external-buildkite#v1:

--- a/pipelines/main/platforms/test_macos.arches
+++ b/pipelines/main/platforms/test_macos.arches
@@ -4,5 +4,7 @@ macos      x86_64-apple-darwin     x86_64        .
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/test_macos.soft_fail.arches
+++ b/pipelines/main/platforms/test_macos.soft_fail.arches
@@ -4,5 +4,7 @@ macos      aarch64-apple-darwin     aarch64       .
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/upload_linux.arches
+++ b/pipelines/main/platforms/upload_linux.arches
@@ -7,5 +7,5 @@ musl       x86_64-linux-musl     .
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Uploads should not take much time
+#default TIMEOUT 30

--- a/pipelines/main/platforms/upload_macos.arches
+++ b/pipelines/main/platforms/upload_macos.arches
@@ -5,5 +5,5 @@ macos      aarch64-apple-darwin        aarch64    .
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most jobs should finish within 1.5 hours, barring exceptionally slow hardware
-#default TIMEOUT 90
+# Uploads should not take much time
+#default TIMEOUT 30

--- a/utilities/proc_utils.jl
+++ b/utilities/proc_utils.jl
@@ -1,0 +1,24 @@
+if Base.VERSION < v"1.6"
+    throw(ErrorException("The `$(basename(@__FILE__))` script requires Julia 1.6 or greater"))
+end
+
+function mirror_exit_code(process::Base.Process)
+    # If the process signalled, let's try to mirror the signal
+    if process.termsignal != 0
+        # Blindly call `raise()` as some signals are fatal by default
+        ccall(:raise, Cvoid, (Cint,), process.termsignal)
+
+        # If that signal doesn't kill us, and we got a nonzero exit
+        # code from the process, go ahead and just mirror that
+        if process.exitcode != 0
+            exit(process.exitcode)
+        else
+            # Otherwise, the process died from a signal that we don't
+            # die from.  Let's just exit with 1 in that case.
+            exit(1)
+        end
+    end
+
+    # If the process didn't signal, just mirror its exit code.
+    exit(process.exitcode)
+end

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -79,7 +79,6 @@ mktempdir(temp_parent_dir) do dir
 
     rr() do rr_path
         capture_script_path = joinpath(dir, "capture_output.sh")
-        loader = Sys.WORD_SIZE == 64 ? "/lib64/ld-linux-x86-64.so.2" : "/lib/ld-linux.so.2"
         open(capture_script_path, "w") do io
             write(io, """
             #!/bin/bash

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -77,6 +77,9 @@ else
     export TESTS="all --ci"
 fi
 
+# Auto-set timeout to buildkite timeout minus 45m for most users
+export JL_TERM_TIMEOUT="$((${BUILDKITE_TIMEOUT:-240}-45))m"
+
 echo "--- Print the list of test sets, and other useful environment variables"
 echo "JULIA_CMD_FOR_TESTS is:    ${JULIA_CMD_FOR_TESTS:?}"
 echo "JULIA_NUM_THREADS is:      ${JULIA_NUM_THREADS:?}"
@@ -84,6 +87,7 @@ echo "NCORES_FOR_TESTS is:       ${NCORES_FOR_TESTS:?}"
 echo "OPENBLAS_NUM_THREADS is:   ${OPENBLAS_NUM_THREADS:?}"
 echo "TESTS is:                  ${TESTS:?}"
 echo "USE_RR is:                 ${USE_RR-}"
+echo "JL_TERM_TIMEOUT is:        ${JL_TERM_TIMEOUT}"
 
 # Show our core dump file pattern and size limit if we're going to be recording them
 if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == "linux" || "${OS}" == "musl" ]]; then
@@ -93,4 +97,4 @@ if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == "linux" || "${OS}" == "musl" ]]; then
 fi
 
 echo "--- Run the Julia test suite"
-${JULIA_CMD_FOR_TESTS:?} -e "Base.runtests(\"${TESTS:?}\"; ncores = ${NCORES_FOR_TESTS:?})"
+"${JULIA_BINARY}" ".buildkite/utilities/timeout.jl" ${JULIA_CMD_FOR_TESTS:?} -e "Base.runtests(\"${TESTS:?}\"; ncores = ${NCORES_FOR_TESTS:?})"

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -10,8 +10,12 @@ set -euo pipefail
 # First, get things like `SHORT_COMMIT`, `JULIA_CPU_TARGET`, `UPLOAD_TARGETS`, etc...
 source .buildkite/utilities/build_envs.sh
 
+# Note that we pass `--step` to prevent ambiguities between downloading the artifacts
+# uploaded by the `build_*` steps vs. the `upload_*` steps.  Normally, testing must occur
+# first, however in the event of a soft-fail test, we can re-run a test after a successful
+# upload has occured.
 echo "--- Download build artifacts"
-buildkite-agent artifact download "${UPLOAD_FILENAME}.tar.gz" .
+buildkite-agent artifact download --step "build_${TRIPLET}" "${UPLOAD_FILENAME}.tar.gz" .
 
 echo "--- Extract build artifacts"
 tar xzf "${UPLOAD_FILENAME}.tar.gz" "${JULIA_INSTALL_DIR}/"

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -94,7 +94,7 @@ echo "USE_RR is:                 ${USE_RR-}"
 echo "JL_TERM_TIMEOUT is:        ${JL_TERM_TIMEOUT}"
 
 # Show our core dump file pattern and size limit if we're going to be recording them
-if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == "linux" || "${OS}" == "musl" ]]; then
+if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == linux* || "${OS}" == "musl" ]]; then
     ulimit -c unlimited
     echo "Core dump pattern:         $(cat /proc/sys/kernel/core_pattern)"
     echo "Core dump size limit:      $(ulimit -c)"

--- a/utilities/timeout.jl
+++ b/utilities/timeout.jl
@@ -1,0 +1,88 @@
+# Usage:    julia timeout.jl [args...]
+#
+# Wraps an execution within a timer that will kill the command after the given time period.
+# We accept timeout arguments via environment variables to avoid having to implement argument
+# parsing in CI scripts.  Note that all time periods are expressed as compound values with
+# suffixes, e.g. "2h30m".  All suffixes are required.
+#
+# Relevant environment variables:
+#
+#  - JL_TERM_TIMEOUT: How long to wait for a task to complete before sending a SIGTERM signal.
+#                     Defaults to 2 hours.
+#  - JL_KILL_TIMEOUT: How long to wait (after the JL_TERM_TIMEOUT) before sending SIGKILL.
+#                     Defaults to 30 minutes.
+#
+# Example:
+#   - JL_TERM_TIMEOUT=2h30m JL_KILL_TIMEOUT=600s julia timeout.jl cmd...
+
+
+# Parse a time period such as "2h30m"
+function parse_time_period(period::AbstractString)
+    unit_to_seconds = Dict(
+        'h' => 60*60,
+        'm' => 60,
+        's' => 1,
+    )
+
+    m = match(r"^(\d+(?:h|m|s))(\d+(?:m|s))?(\d+s)?$", period)
+    total_secs = 0
+    if m === nothing
+        throw(ArgumentError("Invalid time period string '$(period)'"))
+    end
+    for capture in m.captures
+        if capture === nothing
+            continue
+        end
+        value = parse(Int, capture[1:end-1])
+        total_secs += value * unit_to_seconds[capture[end]]
+    end
+    return total_secs
+end
+
+
+# Parse our timeouts
+term_timeout = parse_time_period(get(ENV, "JL_TERM_TIMEOUT", "2h"))
+kill_timeout = parse_time_period(get(ENV, "JL_KILL_TIMEOUT", "30m"))
+
+# Start our child process
+proc = run(`$(ARGS)`, (stdin, stdout, stderr); wait=false)
+
+# Start a watchdog task
+timer_task = @async begin
+    sleep(term_timeout)
+
+    # If the process is still running, ask it nicely to terminate
+    if isopen(proc)
+        println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting termination.")
+        kill(proc, Base.SIGTERM)
+
+        # If the process doesn't stop after a further `kill_timeout`, force-kill it
+        sleep(kill_timeout)
+        if isopen(proc)
+            println(stderr, "\n\nProcess failed to cleanup within $(kill_timeout)s, force-killing!")
+            kill(proc, Base.SIGKILL)
+            exit(1)
+        end
+    end
+end
+
+if Base.VERSION >= v"1.7-"
+    errormonitor(timer_task)
+end
+
+# Wait for the process to finish
+wait(proc)
+
+# Pass the exit code back up, including signals
+if proc.termsignal != 0
+    ccall(:raise, Cvoid, (Cint,), proc.termsignal)
+
+    # If for some reason the signal did not cause an exit, we'll exit manually.
+    # We need to make sure that we exit with a non-zero exit code.
+    if proc.exitcode != 0
+        exit(proc.exitcode)
+    else
+        exit(1)
+    end
+end
+exit(proc.exitcode)


### PR DESCRIPTION
This way, we can get coredumps for stuck processes, hopefully.