### PR TITLE
Add coredump uploading for macOS

### DIFF
--- a/pipelines/main/platforms/test_linux.schedule.yml
+++ b/pipelines/main/platforms/test_linux.schedule.yml
@@ -7,13 +7,13 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
-          - JuliaCI/coreupload#v1:
+          - JuliaCI/coreupload#v2"
               core_pattern: "**/*.core"
               compressor: "zstd"
               disabled: "${USE_RR?}"
               create_bundle: "true"
-              gdb_commands:
-                - "thread apply all bt"
+              lldb_commands:
+                - "bt all"
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -7,13 +7,13 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
-          - JuliaCI/coreupload#v1:
+          - JuliaCI/coreupload#v2:
               core_pattern: "**/*.core"
               compressor: "zstd"
               disabled: "${USE_RR?}"
               create_bundle: "true"
-              gdb_commands:
-                - "thread apply all bt"
+              lldb_commands:
+                - "bt all"
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"

--- a/pipelines/main/platforms/test_macos.yml
+++ b/pipelines/main/platforms/test_macos.yml
@@ -7,6 +7,12 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
+          - JuliaCI/coreupload#v2:
+              core_pattern: "**/*.core"
+              compressor: "zstd"
+              create_bundle: "true"
+              lldb_commands:
+                - "bt all"
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"


### PR DESCRIPTION
Also, prefer using `lldb` over `gdb` on all platforms, as it's more efficient.