### PR TITLE
Fix YAML typo

### DIFF
--- a/pipelines/main/platforms/test_linux.schedule.yml
+++ b/pipelines/main/platforms/test_linux.schedule.yml
@@ -7,7 +7,7 @@ steps:
         depends_on:
           - "build_${TRIPLET?}"
         plugins:
-          - JuliaCI/coreupload#v2"
+          - JuliaCI/coreupload#v2:
               core_pattern: "**/*.core"
               compressor: "zstd"
               disabled: "${USE_RR?}"


### PR DESCRIPTION
I was deceived by the green checkmarks; the "from-source" job had a typo that I failed to see.