### PR TITLE
Don't allow `rr` exit code to kill `rr_capture.jl`

### DIFF
--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -97,7 +97,7 @@ mktempdir(temp_parent_dir) do dir
         new_env["JULIA_RR"] = capture_script_path
         t_start = time()
 
-        global proc = run(setenv(`$(Base.julia_cmd()) $(timeout_script_path) $(rr_path) record --num-cores=$(num_cores) $ARGS`, new_env))
+        global proc = run(ignorestatus(setenv(`$(Base.julia_cmd()) $(timeout_script_path) $(rr_path) record --num-cores=$(num_cores) $ARGS`, new_env)))
         # Wait for `rr` to finish, either through naturally finishing its run, or `SIGTERM`.
         process_failed = !success(proc)
 


### PR DESCRIPTION
We previously had a `wait=false` on this `run()` command, which
implicitly adds an `ignorestatus()`.