### PR TITLE
Move the Apple Silicon builder from "allow fail" to regular (to prepare for promoting Apple Silicon to Tier 2)

### DIFF
--- a/pipelines/main/platforms/build_macos.arches
+++ b/pipelines/main/platforms/build_macos.arches
@@ -1,5 +1,6 @@
 # OS       TRIPLET                  ARCH          MAKE_FLAGS                                TIMEOUT
 macos      x86_64-apple-darwin      x86_64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
+macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/build_macos.soft_fail.arches
+++ b/pipelines/main/platforms/build_macos.soft_fail.arches
@@ -1,8 +1,4 @@
 # OS       TRIPLET                  ARCH          MAKE_FLAGS                                TIMEOUT
-macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
-
-# TODO: move the Apple Silicon build out of the "allow fail" category once we have
-# more Apple Silicon machines.
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
Once this PR is merged, we'll wait a little bit to see how things go on Julia master, and then I'll make a follow-up PR to move the Apple Silicon tester from "allow fail" to regular.