### PR TITLE
Use `-Werror` for building `i686-linux-gnu`

### DIFF
--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -1,5 +1,5 @@
 # OS       TRIPLET                    ARCH           ARCH_ROOTFS    MAKE_FLAGS                                                                    TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
-linux      i686-linux-gnu             x86_64         i686           .                                                                             .             v5.11         b92a539ca132eb2216c5e919eb07fb952f47fbf2
+linux      i686-linux-gnu             x86_64         i686           JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.11         b92a539ca132eb2216c5e919eb07fb952f47fbf2
 linux      x86_64-linux-gnu           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.11         3c62a3dd4116a1b698c103f1e090b824e4cc9ff5
 linux      x86_64-linux-gnuassert     x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .             v5.11         3c62a3dd4116a1b698c103f1e090b824e4cc9ff5
 linux      aarch64-linux-gnu          aarch64        aarch64        .                                                                             .             v5.12         6e0cf5450be71b898d039cc53426a029bc9669ea


### PR DESCRIPTION
I'm here again to add some more `-Werror` :smiling_imp: All warnings should have been cleared up by https://github.com/JuliaLang/julia/pull/45729 and https://github.com/JuliaLang/julia/pull/45753