### PR TITLE
Run the once-daily scheduled "From Source" tester under rr

### DIFF
--- a/pipelines/main/platforms/test_linux.schedule.arches
+++ b/pipelines/main/platforms/test_linux.schedule.arches
@@ -1,5 +1,6 @@
 # OS       TRIPLET                       ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG     ROOTFS_HASH
-linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        .          v5.21          e3fcf9b97c8f37f8de308214e377d99ad2071772
+linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        rr         v5.21          e3fcf9b97c8f37f8de308214e377d99ad2071772
+linux      x86_64-linux-gnusrcassert     x86_64         x86_64         150        rr-net     v5.21          e3fcf9b97c8f37f8de308214e377d99ad2071772
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
The "from source" tester fails frequently; it seems like it fails every single day. Let's run it under rr, which might help us debug why it is failing.