### PR TITLE
Set `ulimit -c unlimited` on macOS as well

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -96,9 +96,13 @@ echo "USE_RR is:                 ${USE_RR-}"
 echo "JL_TERM_TIMEOUT is:        ${JL_TERM_TIMEOUT}"
 
 # Show our core dump file pattern and size limit if we're going to be recording them
-if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == linux* || "${OS}" == musl* || "${OS}" == macos* ]]; then
+if [[ -z "${USE_RR-}" ]]; then
     ulimit -c unlimited
-    echo "Core dump pattern:         $(cat /proc/sys/kernel/core_pattern)"
+    if [[ "${OS}" == linux* || "${OS}" == "musl" ]]; then
+        echo "Core dump pattern:         $(cat /proc/sys/kernel/core_pattern)"
+    elif [[ "${OS}" == "macos" || "${OS}" == "freebsd" ]]; then
+        echo "Core dump pattern:         $(sysctl -n kern.corefile)"
+    fi
     echo "Core dump size limit:      $(ulimit -c)"
 fi
 

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -96,7 +96,7 @@ echo "USE_RR is:                 ${USE_RR-}"
 echo "JL_TERM_TIMEOUT is:        ${JL_TERM_TIMEOUT}"
 
 # Show our core dump file pattern and size limit if we're going to be recording them
-if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == linux* || "${OS}" == "musl" ]]; then
+if [[ -z "${USE_RR-}" ]] && [[ "${OS}" == linux* || "${OS}" == musl* || "${OS}" == macos* ]]; then
     ulimit -c unlimited
     echo "Core dump pattern:         $(cat /proc/sys/kernel/core_pattern)"
     echo "Core dump size limit:      $(ulimit -c)"


### PR DESCRIPTION
We need to actually raise the `ulimit` to core dump properly on macOS.
This is why we haven't been getting coredumps on macOS.