### PR TITLE
Move the `i686-linux-gnu` test job from the "Allow Fail" group into its own "Test i686-linux-gnu" group

### DIFF
--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -84,6 +84,22 @@ steps:
               .buildkite/pipelines/main/platforms/test_macos.yml
         agents:
           queue: "julia"
+  - group: "Test i686-linux-gnu"
+    steps:
+      - label: "Launch the i686-linux-gnu test job"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          # Launch the i686-linux-gnu test job
+          GROUP="Test i686-linux-gnu" \
+              ALLOW_FAIL="true" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/test_linux.32.arches \
+              .buildkite/pipelines/main/platforms/test_linux.32.yml
+        agents:
+          queue: "julia"
   - group: "Allow Fail"
     steps:
       - label: "Launch allowed-to-fail build jobs"

--- a/pipelines/main/platforms/test_linux.32.arches
+++ b/pipelines/main/platforms/test_linux.32.arches
@@ -1,0 +1,10 @@
+# OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+linux      i686-linux-gnu             x86_64         i686           .          .        v5.26         6d4fd1e558e46f09f4103c26707550f66160476d
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 135

--- a/pipelines/main/platforms/test_linux.32.yml
+++ b/pipelines/main/platforms/test_linux.32.yml
@@ -1,0 +1,46 @@
+steps:
+  - group: "${GROUP?}"
+    steps:
+      - label: ":linux: test ${TRIPLET?}${USE_RR-}"
+        key: "test_${TRIPLET?}${USE_RR-}"
+        notify:
+          - github_commit_status:
+              context: "${GROUP?}"
+        if: (build.source != "schedule") || (pipeline.slug == "julia-buildkite")
+        depends_on:
+          - "build_${TRIPLET?}"
+        plugins:
+          - JuliaCI/coreupload#v2:
+              core_pattern: "**/*.core"
+              compressor: "zstd"
+              disabled: "${USE_RR?}"
+              create_bundle: "true"
+              lldb_commands:
+                - "bt all"
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              # Drop default "registries" directory, so it is not persisted from execution to execution
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.6'
+          - staticfloat/sandbox#v1:
+              rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/${ROOTFS_TAG?}/tester_${OS?}.${ARCH_ROOTFS?}.tar.gz
+              rootfs_treehash: "${ROOTFS_HASH?}"
+              uid: 1000
+              gid: 1000
+              workspaces:
+                # Include `/cache/repos` so that our `git` version introspection works.
+                - "/cache/repos:/cache/repos"
+        timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
+        commands: "bash .buildkite/utilities/test_julia.sh"
+        agents:
+          queue: "julia"
+          sandbox_capable: "true"
+          os: "linux"
+          arch: "${ARCH?}"
+        env:
+          JULIA_SHELL: "/bin/bash"
+          TRIPLET: "${TRIPLET?}"
+          USE_RR: "${USE_RR?}"

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,5 +1,4 @@
 # OS       TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-linux      i686-linux-gnu             x86_64         i686           .          .        v5.26         6d4fd1e558e46f09f4103c26707550f66160476d
 linux      aarch64-linux-gnu          aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
 # linux    armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
 linux      powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6


### PR DESCRIPTION
I don't want to keep the Linux i686 test job in the "Allow Fail" group, because this is a Tier 1 platform, and if the job is in the "Allow Fail" group, it can be easy to not notice when it fails.

I'd like to move it from the "Allow Fail" group to the "Test" group. But because it is still failing so frequently (due to out-of-memory issues), putting it in the "Test" group will cause the "Test" group to very frequently be red, which will lead to:
1. Users will become desensitized to the "Test" group being red.
2. Users may stop checking the "Test" group when it is red.
3. Users may start to not notice when other jobs in the "Test" group (other than the Linux i686 test job) are failing.

So, as a middle ground, I'm going to put it in its own group, called "Linux i686 Tests".

Once we get this job to be consistently green, we will move it into the "Test" group.

See also: #166