### PR TITLE
At the end of each test job, upload all files in the `JULIA_TEST_VERBOSE_LOGS_DIR` directory as Buildkite artifacts

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -40,9 +40,6 @@ export OPENBLAS_NUM_THREADS="${JULIA_CPU_THREADS}"
 unset JULIA_DEPOT_PATH
 unset JULIA_PKG_SERVER
 
-# Show the output from the Pkg tests
-export JULIA_PKG_TEST_QUIET="false"
-
 # Make sure that temp files and temp directories are created in a location that is
 # backed by real storage, and not by a tmpfs, as some tests don't like that on Linux
 if [[ "${OS}" == "linux" ]]; then


### PR DESCRIPTION
When testing Julia:

1. Do not set the `JULIA_PKG_TEST_QUIET` environment variable.
2. Create a temporary directory and set the `JULIA_TEST_VERBOSE_LOGS_DIR` environment variable to that directory.
3. At the end of each test job, whether or not the tests pass, upload all files in the `JULIA_TEST_VERBOSE_LOGS_DIR` directory as Buildkite artifacts.