### PR TITLE
Temporarily disable threads on the non-rr jobs

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -67,7 +67,8 @@ if [[ "${USE_RR-}" == "rr" ]] || [[ "${USE_RR-}" == "rr-net" ]]; then
 else
     export JULIA_CMD_FOR_TESTS="${JULIA_BINARY}"
     export NCORES_FOR_TESTS="${JULIA_CPU_THREADS}"
-    export JULIA_NUM_THREADS="${JULIA_CPU_THREADS}"
+    # export JULIA_NUM_THREADS="${JULIA_CPU_THREADS}" # TODO: uncomment this line once we support running CI with threads
+    export JULIA_NUM_THREADS=1 # TODO: delete this line once we support running CI with threads
 
     # Run all tests; `--ci` asserts that networking is available
     export TESTS="all --ci"


### PR DESCRIPTION
We already disable threads on the rr jobs.

We would like to have multiple threads on the non-rr jobs, but per @vtjnash this is not yet a supported CI configuration. So, for now, we will disable threads on the non-rr jobs, with the intention of enabling multiple threads in the future.