### PR TITLE
[DO NOT MERGE] Enable threads on the non-`rr` jobs

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -67,8 +67,7 @@ if [[ "${USE_RR-}" == "rr" ]] || [[ "${USE_RR-}" == "rr-net" ]]; then
 else
     export JULIA_CMD_FOR_TESTS="${JULIA_BINARY}"
     export NCORES_FOR_TESTS="${JULIA_CPU_THREADS}"
-    # export JULIA_NUM_THREADS="${JULIA_CPU_THREADS}" # TODO: uncomment this line once we support running CI with threads
-    export JULIA_NUM_THREADS=1 # TODO: delete this line once we support running CI with threads
+    export JULIA_NUM_THREADS="${JULIA_CPU_THREADS}"
 
     # Run all tests; `--ci` asserts that networking is available
     export TESTS="all --ci"


### PR DESCRIPTION
Follow-up to #185

I'll leave this open as a reminder for us to re-enable threads (on the non-`rr` jobs) once that becomes a supported CI configuration.