### PR TITLE
Split the `i686-linux-gnu` tests up into two groups: "all tests except `Downloads` and `Pkg`" and "only the `Downloads` tests"

### DIFF
--- a/pipelines/main/platforms/test_linux.32.arches
+++ b/pipelines/main/platforms/test_linux.32.arches
@@ -1,5 +1,6 @@
-# ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-tester_linux           i686-linux-gnu             x86_64         i686           .          .        v5.26         6d4fd1e558e46f09f4103c26707550f66160476d
+# ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR    i686_GROUP    i686_LABEL    ROOTFS_TAG    ROOTFS_HASH
+tester_linux           i686-linux-gnu             x86_64         i686           .          .         no-net        .             v5.26         6d4fd1e558e46f09f4103c26707550f66160476d
+tester_linux           i686-linux-gnu             x86_64         i686           .          .         net           net           v5.26         6d4fd1e558e46f09f4103c26707550f66160476d
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.32.yml
+++ b/pipelines/main/platforms/test_linux.32.yml
@@ -1,8 +1,8 @@
 steps:
   - group: "${GROUP?}"
     steps:
-      - label: ":linux: test ${TRIPLET?}${USE_RR-}"
-        key: "test_${TRIPLET?}${USE_RR-}"
+      - label: ":linux: test ${TRIPLET?}${USE_RR-}${i686_LABEL-}"
+        key: "test_${TRIPLET?}${USE_RR-}${i686_LABEL-}"
         notify:
           - github_commit_status:
               context: "${GROUP?}"
@@ -44,3 +44,4 @@ steps:
           JULIA_SHELL: "/bin/bash"
           TRIPLET: "${TRIPLET?}"
           USE_RR: "${USE_RR?}"
+          i686_GROUP: "${i686_GROUP?}"

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,8 +1,8 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-tester_linux          aarch64-linux-gnu          aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
-# tester_linux        armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
-tester_linux          powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
-tester_musl           x86_64-linux-musl          x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
+tester_linux           aarch64-linux-gnu          aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
+# tester_linux         armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
+tester_linux           powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
+tester_musl            x86_64-linux-musl          x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
The frequency of `i686-linux-gnu` test failures has gone down. I think there are two main causes:
1. We stopped running the Pkg tests on `i686-linux-gnu` (https://github.com/JuliaCI/julia-buildkite/pull/176/commits/f67fb96b063716615560ace3152ae2994a2a8d37, which was included in [#176](#176)).
2. We disabled threads, i.e. we set `JULIA_NUM_THREADS` to `1` ([#185](https://github.com/JuliaCI/julia-buildkite/pull/185)).

The only failure that I am still seeing consistently on `i686-linux-gnu` is https://github.com/JuliaLang/julia/issues/46159.

Therefore, this PR splits the `i686-linux-gnu` tests into two groups:

1. All tests except `Downloads` and `Pkg`.
2. Only the `Downloads` tests.

Recall that currently, the `i686-linux-gnu` tests are marked as "allow fail". If this PR goes well, then we can move the "all tests except `Downloads` and `Pkg`" group from "allow fail" to "regular", while keeping the "only the `Downloads` tests" group as "allow fail".