### PR TITLE
Do not test FileWatching on macos

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -75,6 +75,11 @@ elif [[ "${USE_RR-}" == "" ]]; then
         # address space when running the Pkg tests pretty often.
         export TESTS="${TESTS:?} --skip Pkg"
     fi
+    
+    if [[ "${OS}" == "macos" ]]; then
+        # macos does some weird things with event handling which means the tests are unreliable
+        export TESTS="${TESTS:?} --skip FileWatching"
+    fi
 
     if [[ "${i686_GROUP-}" == "no-net" ]]; then
         # We only run Pkg tests on non-32-bit operating systems, as we exhaust the


### PR DESCRIPTION
Macos does some odd stuff with event handling, I tried disabling some of the main culprit tests on the julia repo, but it seems they are all unreliable so I'd rather disable them all while we find some solution to it.

Maybe test them during the nightly run only just to keep coverage?