### PR TITLE
Automatically `git commit` when we `make sign_treehashes`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ decrypt:
 
 sign_treehashes:
 	cd .buildkite/cryptic_repo_root && sign_treehashes --repo-root=$$(pwd) --verbose
+	git commit -a -m "sign treehashes"
 
 verify_treehashes:
 	cd .buildkite/cryptic_repo_root && verify_treehashes --repo-root=$$(pwd) --verbose


### PR DESCRIPTION
This just makes it easier for me when I'm pounding the keyboard in a rage of committing fervor.