### PR TITLE
Makefile: add a new `nocommit_sign_treehashes` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 export PATH := $(shell pwd)/cryptic-buildkite-plugin/bin:$(PATH)
 
+.PHONY: decrypt
 decrypt:
 	cd .buildkite/cryptic_repo_root && decrypt --repo-root=$$(pwd) --verbose
 
-sign_treehashes:
+.PHONY: nocommit_sign_treehashes
+nocommit_sign_treehashes:
 	cd .buildkite/cryptic_repo_root && sign_treehashes --repo-root=$$(pwd) --verbose
+
+.PHONY: sign_treehashes
+sign_treehashes: nocommit_sign_treehashes
 	git commit -a -m "sign treehashes"
 
+.PHONY: verify_treehashes
 verify_treehashes:
 	cd .buildkite/cryptic_repo_root && verify_treehashes --repo-root=$$(pwd) --verbose


### PR DESCRIPTION
Often, I'll find myself working on two PRs at the same time, where each PR modifies a different signed pipeline. Because they modify different pipelines, there shouldn't be any reason for the signatures to cause a merge conflict. However, whenever we sign the treehashes, we sign _all_ of the treehashes, and thus generate new signatures for all signed pipelines. So in this case, instead of doing a `git commit -a`, I want to do a `git add only_a_single_signature.signature` and then `git commit`. That way, once I've merged one of my PRs, there won't be any merge conflicts on the second PR.