### PR TITLE
Fix a typo in the "allow fail" setting for the "from source" tests

### DIFF
--- a/pipelines/scheduled/launch_unsigned_jobs.yml
+++ b/pipelines/scheduled/launch_unsigned_jobs.yml
@@ -22,7 +22,7 @@ steps:
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           GROUP="Source Build" \
-              ALLOW_FAIL="true" \
+              ALLOW_FAIL="false" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/scheduled/platforms/build_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
@@ -38,7 +38,7 @@ steps:
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: |
           GROUP="Source Tests (Allow Fail)" \
-              ALLOW_FAIL="false" \
+              ALLOW_FAIL="true" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/scheduled/platforms/test_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml


### PR DESCRIPTION
Follow-up to #219 