### PR TITLE
Improve the commit message generated by deploy_docs workflow

### DIFF
--- a/pipelines/main/misc/deploy_docs.yml
+++ b/pipelines/main/misc/deploy_docs.yml
@@ -56,8 +56,10 @@ steps:
           tar -zxf ../julia-*-htmldocs.tar.gz
 
           # Build commit message
-          echo "build based on $${BUILDKITE_COMMIT}\n" > ../commit_message
+          echo "build based on $${BUILDKITE_COMMIT}" > ../commit_message
+          echo >> ../commit_message
           echo "build link: $${BUILDKITE_BUILD_URL}" >> ../commit_message
+          echo "commit link: https://github.com/JuliaLang/julia/commit/$${BUILDKITE_COMMIT}" >> ../commit_message
 
           # Add all files to our new commit
           git config --global user.name "Documenter.jl"


### PR DESCRIPTION
Based on Fredrik's suggestions on Slack:

1. Remove the `\n` from the end of the commit message, and make sure we insert a real empty line.
2. Add a full link to the commit in the commit message.