### PR TITLE
Windows: Move `x86_64-w64-mingw32` and `i686-w64-mingw32` from "allow fail" to "regular"

### DIFF
--- a/pipelines/main/platforms/test_windows.arches
+++ b/pipelines/main/platforms/test_windows.arches
@@ -1,0 +1,11 @@
+# OS       TRIPLET                ARCH          TIMEOUT
+windows    x86_64-w64-mingw32     x86_64        .
+windows    i686-w64-mingw32       x86_64        .
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
+# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# including things like `rr` trace compression,
+#default TIMEOUT 225

--- a/pipelines/main/platforms/test_windows.soft_fail.arches
+++ b/pipelines/main/platforms/test_windows.soft_fail.arches
@@ -1,6 +1,4 @@
 # OS       TRIPLET                ARCH          TIMEOUT
-windows    x86_64-w64-mingw32     x86_64        .
-windows    i686-w64-mingw32       x86_64        .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
Needs https://github.com/JuliaLang/julia/pull/47404 to be merged first.