### PR TITLE
Remove the `github_commit_status` invocation from `test_linux.32.yml`

### DIFF
--- a/pipelines/main/platforms/test_linux.32.yml
+++ b/pipelines/main/platforms/test_linux.32.yml
@@ -3,9 +3,6 @@ steps:
     steps:
       - label: ":linux: test ${TRIPLET?}${USE_RR-}${i686_LABEL-}"
         key: "test_${TRIPLET?}${USE_RR-}${i686_LABEL-}"
-        notify:
-          - github_commit_status:
-              context: "${GROUP?}"
         depends_on:
           - "build_${TRIPLET?}"
         plugins:


### PR DESCRIPTION
Let's see if this fixes the following bug that I was seeing:

> I think we have a problem with the commit statuses. For example, the Test status shows up as a green checkmark in GitHub as soon as one of the test jobs is passing, even if every other test job is still running.
>
> Are we doing something wrong, or is this a bug in Buildkite?