### PR TITLE
Reduce the timeout time for rr-net

### DIFF
--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,7 +1,7 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
 tester_linux           x86_64-linux-gnu           x86_64         x86_64         .          .          v5.26         777ec4aa795558b5dcc659903c6bd0a0b3565ed4
 tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v5.26         777ec4aa795558b5dcc659903c6bd0a0b3565ed4
-tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         360        rr-net     v5.26         777ec4aa795558b5dcc659903c6bd0a0b3565ed4
+tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         90         rr-net     v5.26         777ec4aa795558b5dcc659903c6bd0a0b3565ed4
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
rr-net either passes on about 30 min or times out. So reducing the timeout so the worker doesn't stay stuck there for 5 hours.