### PR TITLE
`devdocs`: remind users to push after they sign the treehashes

### DIFF
--- a/devdocs/sign.md
+++ b/devdocs/sign.md
@@ -24,4 +24,5 @@ export AGENT_PRIVATE_KEY_PATH=/path/to/my/agent.key
 make sign_treehashes
 unset AGENT_PRIVATE_KEY_PATH
 rm -f /path/to/my/agent.key
+git push origin YOURINITIALS/YOUR-BRANCH-NAME
 ```


### PR DESCRIPTION
`make sign_treehashes` has become more automagic - in particular, it automatically commits after it generates the new signatures. So users might be fooled into thinking that it also pushes, which it does not. So let's make sure that the devdocs remind users to push.