### PR TITLE
Don't hard code the analyzegc deps

### DIFF
--- a/pipelines/main/misc/analyzegc.yml
+++ b/pipelines/main/misc/analyzegc.yml
@@ -22,7 +22,7 @@ steps:
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C src install-analysis-deps
           echo "+++ run clangsa/analyzegc"
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C test/clangsa
-          make --output-sync -j$${JULIA_CPU_THREADS:?} -C src analyzegc
+          make --output-sync -j$${JULIA_CPU_THREADS:?} -C src analyze
         timeout_in_minutes: 60
         agents:
           queue: "julia"

--- a/pipelines/main/misc/analyzegc.yml
+++ b/pipelines/main/misc/analyzegc.yml
@@ -19,7 +19,7 @@ steps:
                 - "/cache/repos:/cache/repos"
         commands: |
           echo "--- Install in-tree LLVM dependencies"
-          make --output-sync -j$${JULIA_CPU_THREADS:?} -C deps install-llvm install-clang install-llvm-tools install-libuv install-utf8proc install-unwind
+          make --output-sync -j$${JULIA_CPU_THREADS:?} -C src install-analysis-deps
           echo "+++ run clangsa/analyzegc"
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C test/clangsa
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C src analyzegc


### PR DESCRIPTION
The hard coded makefile call exists so don't hard code it :)

EDIT: The reason for this is so I can pass mimalloc.h to analyzegc. Or any other dep for that matter.