### PR TITLE
Update sandbox-buildkite-plugin instead of locking to v1.2

### DIFF
--- a/pipelines/main/misc/analyzegc.yml
+++ b/pipelines/main/misc/analyzegc.yml
@@ -11,7 +11,7 @@ steps:
               # Drop default "registries" directory, so it is not persisted from execution to execution
               persist_depot_dirs: packages,artifacts,compiled
               version: '1.6'
-          - staticfloat/sandbox#v1.2:
+          - staticfloat/sandbox#v1:
               rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v4.8/llvm_passes.x86_64.tar.gz
               rootfs_treehash: "c7a289a8cc544b234b1e2d7cbcce3e6815359ecd"
               workspaces:

--- a/pipelines/main/misc/llvmpasses.yml
+++ b/pipelines/main/misc/llvmpasses.yml
@@ -8,7 +8,7 @@ steps:
               # Drop default "registries" directory, so it is not persisted from execution to execution
               persist_depot_dirs: packages,artifacts,compiled
               version: '1.6'
-          - staticfloat/sandbox#v1.2:
+          - staticfloat/sandbox#v1:
               rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v4.8/package_linux.x86_64.tar.gz
               rootfs_treehash: "2a058481b567f0e91b9aa3ce4ad4f09e6419355a"
               uid: 1000


### PR DESCRIPTION
This should include a fix meant to solve `EBUSY` errors due to copying `/bin/bash` instead of moving it.