### PR TITLE
[release-1.6 only] Drop `--ci` argument to test suite

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -5,7 +5,7 @@ set -euo pipefail
 # Buildkite users can trigger new builds with these values overridden to
 # test specific julia gitshas
 UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/JuliaLang/julia.git}"
-UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-master}"
+UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-release-1.6}"
 
 # All of our workers are required to provide a default for the julia cache dir
 # We're going to cache repositories in here, just like buildkite itself would:

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -104,11 +104,10 @@ else
 fi
 
 # Build our `TESTS` string
-# `--ci` asserts that networking is available
 if [[ "${#TESTS_TO_SKIP[@]}" -gt 0 ]]; then
-    export TESTS="${TESTS_TO_RUN[@]} --ci --skip ${TESTS_TO_SKIP[@]}"
+    export TESTS="${TESTS_TO_RUN[@]} --skip ${TESTS_TO_SKIP[@]}"
 else
-    export TESTS="${TESTS_TO_RUN[@]} --ci"
+    export TESTS="${TESTS_TO_RUN[@]}"
 fi
 
 # Auto-set timeout to buildkite timeout minus 45m for most users


### PR DESCRIPTION
We don't have `--ci` (or `--force-net`, its replacement) in v1.6