### PR TITLE
Only run doctests on `doctest_capable` agents

### DIFF
--- a/pipelines/main/misc/doctest.yml
+++ b/pipelines/main/misc/doctest.yml
@@ -48,5 +48,6 @@ steps:
         agents:
           queue: "julia"
           sandbox_capable: "true"
+          doctest_capable: "true"
           os: "linux"
           arch: "x86_64"


### PR DESCRIPTION
We're going to dodge the issue of slightly-varying floating point results on different machines by only running doctests on amdci machines, which self-report by setting `doctest_capable`.

(cherry picked from commit 01c560f7ee15f4fb54abb0f55302ac5f03489649)