### PR TITLE
Workaround artifact selection problem with bughunt's `rr`

### DIFF
--- a/debugging/bughunt/common.jl
+++ b/debugging/bughunt/common.jl
@@ -131,7 +131,13 @@ end
 # Download `rr` for the given platform, into the given prefix
 function download_rr(platform::Platform, prefix::String)
     if !isfile(joinpath(prefix, "bin", "rr"))
-        paths = collect_artifact_paths(["rr_jll"]; platform)
+        jlls = [
+            Pkg.PackageSpec(;name = "rr_jll", version = v"5.5.0"),
+            # Manually work around bad artifact selection with MSAN tags
+            Pkg.PackageSpec(;name = "Zlib_jll", version = v"1.2.11"),
+        ]
+        paths = collect_artifact_paths(jlls; platform)
+        @show paths
         copy_artifact_paths(prefix, paths)
     end
 end

--- a/debugging/bughunt/common.jl
+++ b/debugging/bughunt/common.jl
@@ -137,7 +137,6 @@ function download_rr(platform::Platform, prefix::String)
             Pkg.PackageSpec(;name = "Zlib_jll", version = v"1.2.11"),
         ]
         paths = collect_artifact_paths(jlls; platform)
-        @show paths
         copy_artifact_paths(prefix, paths)
     end
 end


### PR DESCRIPTION
The new `msan` Zlib_jll artifacts get accidentally chosen due to tag confusion, since a normal version of Julia is allowed to choose an `msan` variant, due to there being no "negative" `sanitizer` tag.