### PR TITLE
Add builder and tester for PowerPC with asserts; ppc64le-linux-gnuassert

### DIFF
--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -4,6 +4,7 @@ package_linux          x86_64-linux-gnu               x86_64         x86_64     
 package_linux          x86_64-linux-gnuassert         x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .             v5.26         5b0b851aca3c941b900a1301c13922c6cfc7f211
 package_linux          aarch64-linux-gnu              aarch64        aarch64        .                                                                             .             v5.26         dcf39d10ba43bf13c75d5031c3a88f125780033b
 package_linux          powerpc64le-linux-gnu          powerpc64le    powerpc64le    .                                                                             .             v5.26         45378b056347797ff6a5411c05f86a9119d17d19
+package_linux          powerpc64le-linux-gnuassert    powerpc64le    powerpc64le    FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1                                          .             v5.26         45378b056347797ff6a5411c05f86a9119d17d19
 package_musl           x86_64-linux-musl              x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         c73bbb4c844b34a8ef3bc4c6c68eeb0bc5fdc1e5
 
 # These special lines allow us to embed default values for the columns above.

--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -1,10 +1,10 @@
-# ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    MAKE_FLAGS                                                                    TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
-package_linux          i686-linux-gnu             x86_64         i686           JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         abe9ca251b93980e444738b3996779d60ea7045d
-package_linux          x86_64-linux-gnu           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         5b0b851aca3c941b900a1301c13922c6cfc7f211
-package_linux          x86_64-linux-gnuassert     x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .             v5.26         5b0b851aca3c941b900a1301c13922c6cfc7f211
-package_linux          aarch64-linux-gnu          aarch64        aarch64        .                                                                             .             v5.26         dcf39d10ba43bf13c75d5031c3a88f125780033b
-package_linux          powerpc64le-linux-gnu      powerpc64le    powerpc64le    .                                                                             .             v5.26         45378b056347797ff6a5411c05f86a9119d17d19
-package_musl           x86_64-linux-musl          x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         c73bbb4c844b34a8ef3bc4c6c68eeb0bc5fdc1e5
+# ROOTFS_IMAGE_NAME    TRIPLET                        ARCH           ARCH_ROOTFS    MAKE_FLAGS                                                                    TIMEOUT       ROOTFS_TAG    ROOTFS_HASH
+package_linux          i686-linux-gnu                 x86_64         i686           JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         abe9ca251b93980e444738b3996779d60ea7045d
+package_linux          x86_64-linux-gnu               x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         5b0b851aca3c941b900a1301c13922c6cfc7f211
+package_linux          x86_64-linux-gnuassert         x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .             v5.26         5b0b851aca3c941b900a1301c13922c6cfc7f211
+package_linux          aarch64-linux-gnu              aarch64        aarch64        .                                                                             .             v5.26         dcf39d10ba43bf13c75d5031c3a88f125780033b
+package_linux          powerpc64le-linux-gnu          powerpc64le    powerpc64le    .                                                                             .             v5.26         45378b056347797ff6a5411c05f86a9119d17d19
+package_musl           x86_64-linux-musl              x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                         .             v5.26         c73bbb4c844b34a8ef3bc4c6c68eeb0bc5fdc1e5
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -1,8 +1,8 @@
-# ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
-tester_linux           aarch64-linux-gnu          aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
-# tester_linux         armv7l-linux-gnueabihf     armv7l         armv7l         .          .        ----          ----------------------------------------
-tester_linux           powerpc64le-linux-gnu      powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
-tester_musl            x86_64-linux-musl          x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
+# ROOTFS_IMAGE_NAME    TRIPLET                          ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR   ROOTFS_TAG    ROOTFS_HASH
+tester_linux           aarch64-linux-gnu                aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
+# tester_linux         armv7l-linux-gnueabihf           armv7l         armv7l         .          .        ----          ----------------------------------------
+tester_linux           powerpc64le-linux-gnu            powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
+tester_musl            x86_64-linux-musl                x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -2,6 +2,7 @@
 tester_linux           aarch64-linux-gnu                aarch64        aarch64        .          .        v5.26         9f78e20253bfb31e4668a4ad2fe6a6c94a511ebf
 # tester_linux         armv7l-linux-gnueabihf           armv7l         armv7l         .          .        ----          ----------------------------------------
 tester_linux           powerpc64le-linux-gnu            powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
+tester_linux           powerpc64le-linux-gnuassert      powerpc64le    powerpc64le    .          .        v5.26         37b4e1629a2c2be9399f7ba65ccb020d2a2e60e6
 tester_musl            x86_64-linux-musl                x86_64         x86_64         .          .        v5.20         7a24baa3fa32382694b37c96d9b256561ff75ca3
 
 # These special lines allow us to embed default values for the columns above.


### PR DESCRIPTION
This PR adds pipeline for builder and tester for PowerPC with asserts enabled (for both Julia and LLVM).