### PR TITLE
Remove Win32

### DIFF
--- a/pipelines/main/platforms/build_windows.arches
+++ b/pipelines/main/platforms/build_windows.arches
@@ -1,6 +1,5 @@
 # OS     TRIPLET              ARCH       DOCKER_ARCH   MAKE_FLAGS                                TIMEOUT     DOCKER_TAG
 windows  x86_64-w64-mingw32   x86_64     x86_64        VERBOSE=1                                 .           v5.44
-windows  i686-w64-mingw32     x86_64     i686          VERBOSE=1                                 .           v5.44
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_windows.arches
+++ b/pipelines/main/platforms/test_windows.arches
@@ -1,6 +1,5 @@
 # OS       TRIPLET                ARCH          TIMEOUT
 windows    x86_64-w64-mingw32     x86_64        .
-windows    i686-w64-mingw32       x86_64        .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/upload_windows.arches
+++ b/pipelines/main/platforms/upload_windows.arches
@@ -1,6 +1,5 @@
 # OS     TRIPLET                DOCKER_TAG   TIMEOUT
 windows  x86_64-w64-mingw32     v5.44        .
-windows  i686-w64-mingw32       v5.44        .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
Win 32bit is ~1% of Win 64bit according to the pkg statistics.

Generally speaking it consumes an outsized amount of developer resources
trying to keep everything working on it. I would thus like to stop supporting
Win 32bit as of Julia 1.11
