### PR TITLE
run SIGINFO profile before timeout-terminating test runner

### DIFF
--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -1,7 +1,7 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                    ARCH           ARCH_ROOTFS    TIMEOUT    USE_RR     ROOTFS_TAG    ROOTFS_HASH
 tester_linux           x86_64-linux-gnu           x86_64         x86_64         .          .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
-tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         165        rr-net     v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
+tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         55         rr-net     v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/utilities/timeout.jl
+++ b/utilities/timeout.jl
@@ -64,12 +64,17 @@ timer_task = @async begin
             println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting termination (SIGTERM) of PID $(proc_pid).")
         else
             println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting profile then termination (SIGTERM) of PID $(proc_pid).")
-            if Sys.islinux()
-                kill(proc, 30) # SIGUSR1
-                println(stderr, "\n\nSent SIGUSR1 to PID $(proc_pid).")
-            elseif Sys.isbsd()
-                kill(proc, 29) # SIGINFO
-                println(stderr, "\n\nSent SIGINFO to PID $(proc_pid).")
+            if proc_pid == "<unknown>"
+                println(stderr, "Cannot send signal as process PID is unknown.")
+            else
+                # can't use julia kill function as signal numbers are unstable across platform and not defined in Base
+                if Sys.islinux()
+                    run(`kill -USR1 $proc_pid`)
+                    println(stderr, "\n\nSent SIGUSR1 to PID $(proc_pid).")
+                elseif Sys.isbsd()
+                    run(`kill -INFO $proc_pid`)
+                    println(stderr, "\n\nSent SIGINFO to PID $(proc_pid).")
+                end
             end
             sleep(10) # give time for 1s profile to run and print
         end

--- a/utilities/timeout.jl
+++ b/utilities/timeout.jl
@@ -65,7 +65,7 @@ timer_task = @async begin
         else
             println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting profile then termination (SIGTERM) of PID $(proc_pid).")
             if Sys.islinux()
-                kill(proc, 10) # SIGUSR1
+                kill(proc, 30) # SIGUSR1
                 println(stderr, "\n\nSent SIGUSR1 to PID $(proc_pid).")
             elseif Sys.isbsd()
                 kill(proc, 29) # SIGINFO

--- a/utilities/timeout.jl
+++ b/utilities/timeout.jl
@@ -60,7 +60,19 @@ timer_task = @async begin
 
     # If the process is still running, ask it nicely to terminate
     if isopen(proc)
-        println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting termination (SIGTERM) of PID $(proc_pid).")
+        if Sys.iswindows()
+            println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting termination (SIGTERM) of PID $(proc_pid).")
+        else
+            println(stderr, "\n\nProcess failed to exit within $(term_timeout)s, requesting profile then termination (SIGTERM) of PID $(proc_pid).")
+            if Sys.islinux()
+                kill(proc, 10) # SIGUSR1
+                println(stderr, "\n\nSent SIGUSR1 to PID $(proc_pid).")
+            elseif Sys.isbsd()
+                kill(proc, 29) # SIGINFO
+                println(stderr, "\n\nSent SIGINFO to PID $(proc_pid).")
+            end
+            sleep(10) # give time for 1s profile to run and print
+        end
         kill(proc, Base.SIGTERM)
         println(stderr, "\n\nSent SIGTERM to PID $(proc_pid).")
 


### PR DESCRIPTION
It'd be helpful to know where timing-out processes are in julia code