### PR TITLE
Expand test results by default

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -147,7 +147,8 @@ if [[ -z "${USE_RR-}" ]]; then
     echo "Core dump size limit:      $(ulimit -c)"
 fi
 
-echo "--- Run the Julia test suite"
+# Begin with "+++" => Expand test group by default
+echo "+++ Run the Julia test suite"
 # set -e; requires us using if to check the exit status
 if ${JULIA_CMD_FOR_TESTS:?} -e "Base.runtests(\"${TESTS:?}\"; ncores = ${NCORES_FOR_TESTS:?})"; then
   exitVal=0


### PR DESCRIPTION
Expands the results of test by default.

ref: buildkite doc: [Collapsing output](https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output)

Context:

> Slight annoyance with the new results.json is that the focus is on the "upload results.json" step now
>
> ![image](https://github.com/JuliaCI/julia-buildkite/assets/5158738/a6824b23-b091-4e94-bf8d-3f9df018d5d2)
>
> From slack: https://julialang.slack.com/archives/C0309QBEZNH/p1707423131178209