### PR TITLE
Restore `-Werror` for macOS builds

### DIFF
--- a/pipelines/main/platforms/build_macos.arches
+++ b/pipelines/main/platforms/build_macos.arches
@@ -1,6 +1,6 @@
 # OS       TRIPLET                  ARCH          MAKE_FLAGS                                TIMEOUT
-macos      x86_64-apple-darwin      x86_64        .                                         .
-macos      aarch64-apple-darwin     aarch64       .                                         .
+macos      x86_64-apple-darwin      x86_64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
+macos      aarch64-apple-darwin     aarch64       JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/scheduled/platforms/build_macos.no_gpl.arches
+++ b/pipelines/scheduled/platforms/build_macos.no_gpl.arches
@@ -1,6 +1,6 @@
 # OS       TRIPLET                      ARCH          MAKE_FLAGS                                               TIMEOUT
-macos      x86_64-apple-darwinnogpl     x86_64        USE_GPL_LIBS=0                                           .
-macos      aarch64-apple-darwinnogpl    aarch64       USE_GPL_LIBS=0                                           .
+macos      x86_64-apple-darwinnogpl     x86_64        USE_GPL_LIBS=0,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
+macos      aarch64-apple-darwinnogpl    aarch64       USE_GPL_LIBS=0,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror     .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
I don't see warnings when building Julia on macOS (e.g. see https://buildkite.com/julialang/julia-master/builds/34547), so I think we should restore the `-Werror` flag that was removed in #296 and #297, sounds like the warning mentioned there (without reference, so it's a bit hard to track it) has been since fixed.

***Edit***: ah, the unreferenced warning may have been the one in LLVM mentioned at https://github.com/JuliaLang/julia/pull/49443#issue-1676954397, which was fixed by https://github.com/llvm/llvm-project/commit/39d348c602f08da2505d51f3b224f4ff057207db.