### PR TITLE
Build sysimage with TSAN and upload binary

### DIFF
--- a/pipelines/main/misc/sanitizers/tsan.yml
+++ b/pipelines/main/misc/sanitizers/tsan.yml
@@ -19,8 +19,25 @@ steps:
       if: | # We only run the `tsan` job on Julia 1.8 and later.
         (pipeline.slug != "julia-release-1-dot-6") && (pipeline.slug != "julia-release-1-dot-7")
       commands: |
-        echo "--- Build julia-debug runtime with TSAN"
-        contrib/tsan/build.sh ./tmp/test-tsan -j$${JULIA_CPU_THREADS:?} julia-src-debug
+        echo "--- Build julia with TSAN"
+        contrib/tsan/build.sh ./tmp/test-tsan -j$${JULIA_CPU_THREADS:?}
+
+        echo "--- Create build artifacts"
+        contrib/tsan/build.sh ./tmp/test-tsan -j$${JULIA_CPU_THREADS:?} binary-dist
+        
+        # Get JULIA_BINARYDIST_FILENAME
+        source .buildkite/utilities/build_envs.sh
+        
+        cd ./tmp/test-tsan/tsan
+        UPLOAD_FILENAME +=-tsan
+        
+        # Rename the build artifact in case we want to name it differently, as is the case on `musl`.
+        if [[ "${JULIA_BINARYDIST_FILENAME}.tar.gz" != "${UPLOAD_FILENAME}.tar.gz" ]]; then
+            mv "${JULIA_BINARYDIST_FILENAME}.tar.gz" "${UPLOAD_FILENAME}.tar.gz"
+        fi
+        
+        echo "--- Upload build artifacts to buildkite"
+        buildkite-agent artifact upload "${UPLOAD_FILENAME}.tar.gz"
       agents:
         queue: "julia"
         sandbox_capable: "true"


### PR DESCRIPTION
I removed building julia in debug mode as https://github.com/JuliaLang/julia/pull/48210 switched TSAN to defaulting to building in release mode as debug didn't work.

I'm not sure we can even build the sysimage but let's see.