### PR TITLE
build: set `USE_GPL_LIBS=0` for the `x86_64-w64-mingw32nogpl` builder (affects `buildkite/julia-buildkite-scheduled`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Buildkite
 
+Hello world. Todo remove this line.
+
 This directory contains the Buildkite configuration files for Base Julia CI.
 
 The rootfs image definitions are located in the [rootfs-images](https://github.com/JuliaCI/rootfs-images) repository.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Buildkite
 
-Hello world. Todo remove this line.
-
 This directory contains the Buildkite configuration files for Base Julia CI.
 
 The rootfs image definitions are located in the [rootfs-images](https://github.com/JuliaCI/rootfs-images) repository.

--- a/pipelines/scheduled/platforms/build_windows.no_gpl.arches
+++ b/pipelines/scheduled/platforms/build_windows.no_gpl.arches
@@ -1,5 +1,6 @@
-# OS       TRIPLET                    ARCH       DOCKER_ARCH    MAKE_FLAGS                                              TIMEOUT     DOCKER_TAG
-windows    x86_64-w64-mingw32nogpl    x86_64     x86_64         USE_GPL_LIBS=0,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .           v5.44
+# OS       TRIPLET                    ARCH       DOCKER_ARCH    MAKE_FLAGS      TIMEOUT     DOCKER_TAG
+windows    x86_64-w64-mingw32nogpl    x86_64     x86_64         USE_GPL_LIBS=0  .           v5.44
+# TODO: fix gcc warning, and add flags `JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror` to MAKE_FLAGS
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/scheduled/platforms/build_windows.no_gpl.arches
+++ b/pipelines/scheduled/platforms/build_windows.no_gpl.arches
@@ -1,5 +1,5 @@
-# OS       TRIPLET                    ARCH       DOCKER_ARCH    MAKE_FLAGS    TIMEOUT     DOCKER_TAG
-windows    x86_64-w64-mingw32nogpl    x86_64     x86_64         VERBOSE=1     .           v5.44
+# OS       TRIPLET                    ARCH       DOCKER_ARCH    MAKE_FLAGS                                              TIMEOUT     DOCKER_TAG
+windows    x86_64-w64-mingw32nogpl    x86_64     x86_64         USE_GPL_LIBS=0,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .           v5.44
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
CI `:windows: build x86_64-w64-mingw32nogpl` passed, because the `USE_GPL_LIBS=0` flag is not 

Use same flags as macOS:
https://github.com/JuliaCI/julia-buildkite/blob/ea50eb719242bc3e844227a2ebf54a49d308bafc/pipelines/scheduled/platforms/build_macos.no_gpl.arches#L2

