### PR TITLE
Bump Docker version on windows

### DIFF
--- a/pipelines/main/platforms/build_windows.arches
+++ b/pipelines/main/platforms/build_windows.arches
@@ -1,6 +1,6 @@
 # OS     TRIPLET              ARCH       DOCKER_ARCH   MAKE_FLAGS                                TIMEOUT     DOCKER_TAG
-windows  x86_64-w64-mingw32   x86_64     x86_64        VERBOSE=1                                 .           v5.44
-windows  i686-w64-mingw32     x86_64     i686          VERBOSE=1                                 .           v5.44
+windows  x86_64-w64-mingw32   x86_64     x86_64        VERBOSE=1                                 .           v7.2
+windows  i686-w64-mingw32     x86_64     i686          VERBOSE=1                                 .           v7.2
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
This bumps the msys2 version to the latest release, this comes with new compilers and hopefully fixes the issues where windows builds don't start with odd issues like https://buildkite.com/julialang/julia-master/builds/37295#019002f7-9af5-48ff-9342-d927ac35b35d/1-7