### PR TITLE
Auto-prune upstream caches to avoid errors like the following:

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -22,6 +22,9 @@ if [[ "${DISABLE_UPSTREAM_CACHE}" != "true" ]]; then
         mkdir -p "$(dirname "${UPSTREAM_CACHE}")"
         git clone --mirror "${UPSTREAM_URL}" "${UPSTREAM_CACHE}"
     else
+        echo "Prune cache for ${UPSTREAM_URL}"
+        rm -f "${UPSTREAM_CACHE}/gc.log"
+        git -C "${UPSTREAM_CACHE}" prune
         echo "Update cache for ${UPSTREAM_URL}"
         git -C "${UPSTREAM_CACHE}" fetch
     fi


### PR DESCRIPTION
```
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Cloning into '.'...
Enumerating objects: 426954, done.
Counting objects: 100% (426954/426954), done.
Delta compression using up to 8 threads
Compressing objects: 100% (107059/107059), done.
Writing objects: 100% (426954/426954), done.
Total 426954 (delta 319976), reused 418936 (delta 312528), pack-reused 0
fatal: unable to parse commit 9650510b5fa64571178cb9fe8b6799060ae0a3ac
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```