### PR TITLE
Don't allow failure in FreeBSD test jobs

### DIFF
--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -102,6 +102,11 @@ steps:
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/platforms/test_macos.arches \
               .buildkite/pipelines/main/platforms/test_macos.yml
+          # Launch FreeBSD test jobs
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/platforms/test_freebsd.arches \
+              .buildkite/pipelines/main/platforms/test_freebsd.yml
           # Launch windows test jobs
           GROUP="Test" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \

--- a/pipelines/main/platforms/test_freebsd.arches
+++ b/pipelines/main/platforms/test_freebsd.arches
@@ -1,4 +1,5 @@
 # OS       TRIPLET                 ARCH          TIMEOUT
+freebsd    x86_64-unknown-freebsd  x86_64        .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_freebsd.soft_fail.arches
+++ b/pipelines/main/platforms/test_freebsd.soft_fail.arches
@@ -1,5 +1,4 @@
 # OS       TRIPLET                 ARCH          TIMEOUT
-freebsd    x86_64-unknown-freebsd  x86_64        .
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
The issues with the CI setup that had made it flaky for a while have been fixed. But because the tests are allowed to fail, multiple regressions have snuck in. Once https://github.com/JuliaLang/julia/pull/55594 lands, things will once again be in a stable, working state, so we should require tests to pass to avoid further regressions.