### PR TITLE
Update rr to 5.8

### DIFF
--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -64,7 +64,7 @@ mktempdir(temp_parent_dir) do dir
     # version number, Pkg will always install the latest build number. If you need to
     # install a build number that is not the latest build number, you must provide the
     # commit instead of providing the version number.
-    Pkg.add(Pkg.PackageSpec(name = "rr_jll", version = "5.7.0", uuid = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"))
+    Pkg.add(Pkg.PackageSpec(name = "rr_jll", version = "5.8.0", uuid = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"))
     Pkg.add(Pkg.PackageSpec(name = "Zstd_jll", version = "1.5.0", uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"))
     rr_jll = Base.require(Base.PkgId(Base.UUID("e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"), "rr_jll"))
     zstd_jll = Base.require(Base.PkgId(Base.UUID("3161d3a3-bdf6-5164-811a-617609db77b4"), "Zstd_jll"))

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -1,4 +1,3 @@
-# Hello world
 import Dates, Pkg, Tar
 include(joinpath(dirname(@__DIR__), "proc_utils.jl"))
 

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -1,3 +1,4 @@
+# Hello world
 import Dates, Pkg, Tar
 include(joinpath(dirname(@__DIR__), "proc_utils.jl"))
 


### PR DESCRIPTION
The bump to rr 5.7 (#322) introduced frequent crashes on CI. I fixed this upstream in https://github.com/rr-debugger/rr/commit/07415f58c423053ad024c69918a014275ef6f73f and cherry-picked it into v5.8 of the rr_jll. cc @JeffBezanson 