### PR TITLE
Mark the `test-revise` job as required

### DIFF
--- a/pipelines/main/misc/test_revise.yml
+++ b/pipelines/main/misc/test_revise.yml
@@ -32,7 +32,7 @@ steps:
           unset JULIA_DEPOT_PATH
           JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="Revise", rev="master"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("Revise")'
         timeout_in_minutes: 30
-        soft_fail: true
+        # soft_fail: true
         agents:
           queue: "julia"
           sandbox_capable: "true"


### PR DESCRIPTION
Follow-up to #372.

This PR makes the `test-revise` job required. Thus, if the `test-revise` job fails, the overall build will fail.