### PR TITLE
Bump linux timeouts

### DIFF
--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -6,7 +6,7 @@ tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
-# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# Most tests should finish within ~55 minutes, barring exceptionally slow hardware
+# We double that to a default of 110 minutes, with an extra 45 minutes for cleanup,
 # including things like `rr` trace compression,
-#default TIMEOUT 135
+#default TIMEOUT 155

--- a/pipelines/main/platforms/test_linux.i686.arches
+++ b/pipelines/main/platforms/test_linux.i686.arches
@@ -5,7 +5,7 @@ tester_linux           i686-linux-gnu             x86_64         i686           
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
-# Most tests should finish within ~45 minutes, barring exceptionally slow hardware
-# We double that to a default of 90 minutes, with an extra 45 minutes for cleanup,
+# Most tests should finish within ~55 minutes, barring exceptionally slow hardware
+# We double that to a default of 110 minutes, with an extra 45 minutes for cleanup,
 # including things like `rr` trace compression,
-#default TIMEOUT 135
+#default TIMEOUT 155


### PR DESCRIPTION
We're seeing some intermittent timeouts on linux master CI. However, successful runs are pretty close to the limit (our tests have started to grow over time), so try bumping the timeout. Of course it's possible we do actually have some sort of hang.