### PR TITLE
don't error on missing results*.json

### DIFF
--- a/pipelines/main/misc/upload_buildkite_results.yml
+++ b/pipelines/main/misc/upload_buildkite_results.yml
@@ -19,6 +19,7 @@ steps:
           - test-collector#v1.10.1:
               files: "results*.json"
               format: "json"
+              missing-error: 0
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: true
         commands: |


### PR DESCRIPTION
Ref: https://github.com/buildkite-plugins/test-collector-buildkite-plugin#missing-error-integer

cc. @KristofferC 