### PR TITLE
Disable PowerPC CI

### DIFF
--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -4,8 +4,8 @@ package_linux          x86_64-linux-gnu               x86_64         x86_64     
 package_linux          x86_64-linux-gnuassert         x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror              .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 package_linux          x86_64-linux-gnuprofiling      x86_64         x86_64         WITH_TRACY=1,WITH_ITTAPI=1,WITH_TIMING_COUNTS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror   .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 package_linux          aarch64-linux-gnu              aarch64        aarch64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                                   .             v6.00         e32c05f36d0a5bb0f94a17d99647f0b3352a8256
-package_linux          powerpc64le-linux-gnu          powerpc64le    powerpc64le    .                                                                                       .             v6.00         a7e3fe07d581d5c97e2c7aca85b2273597f21c0b
-package_linux          powerpc64le-linux-gnuassert    powerpc64le    powerpc64le    FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1                                                    .             v6.00         a7e3fe07d581d5c97e2c7aca85b2273597f21c0b
+# package_linux          powerpc64le-linux-gnu          powerpc64le    powerpc64le    .                                                                                       .             v6.00         a7e3fe07d581d5c97e2c7aca85b2273597f21c0b
+# package_linux          powerpc64le-linux-gnuassert    powerpc64le    powerpc64le    FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1                                                    .             v6.00         a7e3fe07d581d5c97e2c7aca85b2273597f21c0b
 # package_musl           x86_64-linux-musl              x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                                   .             v6.00         948ca1e496231e4c280c236a3e9bb01c95c2cda5
 
 # These special lines allow us to embed default values for the columns above.


### PR DESCRIPTION
And though we reached the summit, we did not discover salvation, only misery....

Summit is being turned off tomorrow. As far as we know, that was the last PowerPC platform that anybody was seriously using Julia on. CI has been broken on master recently and nobody seems particularly inclined to fix it, so turn off CI and we'll drop down PowerPC to Tier 4.