### PR TITLE
`launch_powerpc.jl`: Forward env vars to upload script

### DIFF
--- a/pipelines/main/platforms/launch_powerpc.jl
+++ b/pipelines/main/platforms/launch_powerpc.jl
@@ -15,7 +15,7 @@ const arches_file = ARGS[1]
 # .buildkite/pipelines/main/platforms/build_linux.yml
 const yaml_pipeline_file = ARGS[2]
 
-const cmd = `bash ".buildkite/utilities/arches_pipeline_upload.sh" "$(arches_file)" "$(yaml_pipeline_file)"`
+const cmd = Cmd(`bash ".buildkite/utilities/arches_pipeline_upload.sh" "$(arches_file)" "$(yaml_pipeline_file)"`, env=copy(ENV))
 
 const parsed_julia_version = parse_version_file()
 const should_include_powerpc_builds = parsed_julia_version < v"1.12-"


### PR DESCRIPTION
Found this while rebasing #400.

This might address the build failures mentioned here: https://github.com/JuliaCI/julia-buildkite/pull/407#issuecomment-2481823956