### PR TITLE
Shorten make paths in logs, with key at start of log

### DIFF
--- a/utilities/build_julia.sh
+++ b/utilities/build_julia.sh
@@ -62,8 +62,8 @@ for FLAG in "${MFLAGS[@]}"; do
 done
 
 echo "--- Build Julia"
-echo "Note: The log stream is filtered. [julia] replaces pwd $(pwd)"
-${MAKE} "${MFLAGS[@]}" 2>&1 | sed "s|$(pwd)|[julia]|g"
+echo "Note: The log stream is filtered. [buildroot] replaces pwd $(pwd)"
+${MAKE} "${MFLAGS[@]}" 2>&1 | sed "s|$(pwd)|[buildroot]|g"
 
 
 echo "--- Check that the working directory is clean"
@@ -85,8 +85,8 @@ ${JULIA_EXE} -e "import Test; Test.@test Sys.ARCH == :${ARCH:?}"
 ${JULIA_EXE} -e "import Test; Test.@test Sys.WORD_SIZE == ${EXPECTED_WORD_SIZE:?}"
 
 echo "--- Show build stats"
-echo "Note: The log stream is filtered. [julia] replaces pwd $(pwd)"
-${MAKE} "${MFLAGS[@]}" build-stats 2>&1 | sed "s|$(pwd)|[julia]|g"
+echo "Note: The log stream is filtered. [buildroot] replaces pwd $(pwd)"
+${MAKE} "${MFLAGS[@]}" build-stats 2>&1 | sed "s|$(pwd)|[buildroot]|g"
 
 echo "--- Create build artifacts"
 ${MAKE} "${MFLAGS[@]}" binary-dist

--- a/utilities/build_julia.sh
+++ b/utilities/build_julia.sh
@@ -85,7 +85,8 @@ ${JULIA_EXE} -e "import Test; Test.@test Sys.ARCH == :${ARCH:?}"
 ${JULIA_EXE} -e "import Test; Test.@test Sys.WORD_SIZE == ${EXPECTED_WORD_SIZE:?}"
 
 echo "--- Show build stats"
-${MAKE} "${MFLAGS[@]}" build-stats
+echo "Note: The log stream is filtered. [julia] replaces pwd $(pwd)"
+${MAKE} "${MFLAGS[@]}" build-stats 2>&1 | sed "s|$(pwd)|[julia]|g"
 
 echo "--- Create build artifacts"
 ${MAKE} "${MFLAGS[@]}" binary-dist

--- a/utilities/build_julia.sh
+++ b/utilities/build_julia.sh
@@ -62,7 +62,8 @@ for FLAG in "${MFLAGS[@]}"; do
 done
 
 echo "--- Build Julia"
-${MAKE} "${MFLAGS[@]}"
+echo "Note: The log stream is filtered. [julia] replaces pwd $(pwd)"
+${MAKE} "${MFLAGS[@]}" 2>&1 | sed "s|$(pwd)|[julia]|g"
 
 
 echo "--- Check that the working directory is clean"


### PR DESCRIPTION
Because they're so long that it makes logs hard to read.

Before
![Screenshot 2024-12-29 at 9 40 13 PM](https://github.com/user-attachments/assets/13d33d43-dbc1-427f-9b89-3f32ce2f5d68)


This PR
![Screenshot 2024-12-29 at 9 41 58 PM](https://github.com/user-attachments/assets/e3ed090e-2462-4205-8bca-267de43ea62c)



