### PR TITLE
Upload after build without waiting for tests

### DIFF
--- a/pipelines/main/platforms/upload_freebsd.yml
+++ b/pipelines/main/platforms/upload_freebsd.yml
@@ -6,8 +6,6 @@ steps:
         depends_on:
           # Wait for the builder to finish
           - "build_${TRIPLET?}"
-          # Wait for the tester to finish
-          - "test_${TRIPLET?}"
         # Prevent multiple pipelines from uploading to S3 simultaneously
         # It is okay for two different triplets to upload simultaneously
         concurrency: 1

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -6,8 +6,6 @@ steps:
         depends_on:
           # Wait for the builder to finish
           - "build_${TRIPLET?}"
-          # Wait for the tester to finish
-          - "test_${TRIPLET?}"
         # Prevent multiple pipelines from uploading to S3 simultaneously
         # It is okay for two different triplets to upload simultaneously
         concurrency: 1

--- a/pipelines/main/platforms/upload_macos.yml
+++ b/pipelines/main/platforms/upload_macos.yml
@@ -6,8 +6,6 @@ steps:
         depends_on:
           # Wait for the builder to finish
           - "build_${TRIPLET?}"
-          # Wait for the tester to finish
-          - "test_${TRIPLET?}"
         # Prevent multiple pipelines from uploading to S3 simultaneously
         # It is okay for two different triplets to upload simultaneously
         concurrency: 1

--- a/pipelines/main/platforms/upload_windows.yml
+++ b/pipelines/main/platforms/upload_windows.yml
@@ -6,8 +6,6 @@ steps:
         depends_on:
           # Wait for the builder to finish
           - "build_${TRIPLET?}"
-          # Wait for the tester to finish
-          - "test_${TRIPLET?}"
         # Prevent multiple pipelines from uploading to S3 simultaneously
         # It is okay for two different triplets to upload simultaneously
         concurrency: 1


### PR DESCRIPTION
I propose this change because currently if tests fail, the build does not upload. I think some of the point of using nightly/pr-builds is to test things manually, and potentially to debug failing tests and issues like that. Therefore, I don't think uploads should be gated on tests passing.