### PR TITLE
Mark mmtk CI tests as softfail

### DIFF
--- a/pipelines/main/platforms/build_linux.arches
+++ b/pipelines/main/platforms/build_linux.arches
@@ -4,7 +4,6 @@ package_linux          x86_64-linux-gnu               x86_64         x86_64     
 package_linux          x86_64-linux-gnuassert         x86_64         x86_64         FORCE_ASSERTIONS=1,LLVM_ASSERTIONS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                      .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 package_linux          x86_64-linux-gnuprofiling      x86_64         x86_64         WITH_TRACY=1,WITH_ITTAPI=1,WITH_TIMING_COUNTS=1,JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror           .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 package_linux          aarch64-linux-gnu              aarch64        aarch64        JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                                           .             v6.00         e32c05f36d0a5bb0f94a17d99647f0b3352a8256
-package_linux          x86_64-linux-gnummtk           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror,WITH_THIRD_PARTY_GC=mmtk,MMTK_PLAN=Immix,MMTK_MOVING=0    .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 # package_musl           x86_64-linux-musl              x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror                                                         .             v6.00         948ca1e496231e4c280c236a3e9bb01c95c2cda5
 
 # These special lines allow us to embed default values for the columns above.

--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -1,5 +1,6 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                   ARCH           ARCH_ROOTFS    MAKE_FLAGS                               TIMEOUT     ROOTFS_TAG    ROOTFS_HASH
 package_musl           x86_64-linux-musl         x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .           v6.00         948ca1e496231e4c280c236a3e9bb01c95c2cda5
+package_linux          x86_64-linux-gnummtk           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror,WITH_THIRD_PARTY_GC=mmtk,MMTK_PLAN=Immix,MMTK_MOVING=0    .             v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
 # package_linux        armv7l-linux-gnueabihf    armv7l         armv7l         .                                        .           ----          ----------------------------------------
 
 

--- a/pipelines/main/platforms/test_linux.arches
+++ b/pipelines/main/platforms/test_linux.arches
@@ -2,7 +2,6 @@
 tester_linux           x86_64-linux-gnu           x86_64         x86_64         .          .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         360        rr         v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 tester_linux           x86_64-linux-gnuassert     x86_64         x86_64         165        rr-net     v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
-tester_linux           x86_64-linux-gnummtk      x86_64         x86_64         .          .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/platforms/test_linux.soft_fail.arches
+++ b/pipelines/main/platforms/test_linux.soft_fail.arches
@@ -2,6 +2,7 @@
 tester_linux           aarch64-linux-gnu                aarch64        aarch64        165        .        v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b
 # tester_linux         armv7l-linux-gnueabihf           armv7l         armv7l         .          .        ----          ----------------------------------------
 tester_musl            x86_64-linux-musl                x86_64         x86_64         .          .        v6.00         6eaef301e981bbcdbc054c5b6d4f33c7eaedb64a
+tester_linux           x86_64-linux-gnummtk      x86_64         x86_64         .          .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
As I said in https://github.com/JuliaCI/julia-buildkite/pull/419#issuecomment-2635689784, mmtk should be softfail unless and until the root scanner is moved into the main julia repo so that ABI changes don't depend on an external repo. Otherwise we would slow down base Julia evolution for an experimental feature, which is not reasonable.