### PR TITLE
Add utility to find the latest common denominator Julia version

### DIFF
--- a/utilities/julia_version_selection/Manifest.toml
+++ b/utilities/julia_version_selection/Manifest.toml
@@ -1,0 +1,137 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.3"
+manifest_format = "2.0"
+project_hash = "23f7a7c414b93b4fd223b2486b8aed83d346b1cd"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.JSON3]]
+deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
+git-tree-sha1 = "1d322381ef7b087548321d3f878cb4c9bd8f8f9b"
+uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+version = "1.14.1"
+
+    [deps.JSON3.extensions]
+    JSON3ArrowExt = ["ArrowTypes"]
+
+    [deps.JSON3.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.1"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "159331b30e94d7b11379037feeb9b690950cace8"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"

--- a/utilities/julia_version_selection/Project.toml
+++ b/utilities/julia_version_selection/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/utilities/julia_version_selection/README.md
+++ b/utilities/julia_version_selection/README.md
@@ -1,0 +1,3 @@
+# Finding the latest common Julia version
+
+For our generic jobs (such as upload jobs) it is useful to know what's the latest version of Julia that is supported on all our build systems.  Currently, the answer is quite depressing if we include both `armv7l` and `ppc64le` (`1.6.3`).

--- a/utilities/julia_version_selection/get_latest_common_denominator_julia.jl
+++ b/utilities/julia_version_selection/get_latest_common_denominator_julia.jl
@@ -1,0 +1,51 @@
+using Downloads, JSON3, Base.BinaryPlatforms
+
+json_buff = IOBuffer()
+Downloads.download("https://julialang-s3.julialang.org/bin/versions.json", json_buff)
+versions_json = JSON3.read(String(take!(json_buff)))
+
+root_dir = dirname(dirname(@__DIR__))
+
+# Read the set of triplets from our .arches files:
+function read_arches_file(arches_file)
+    triplets_script = """
+    bash $(root_dir)/utilities/arches_env.sh $(arches_file) | while read env_map; do
+        eval "export \${env_map}"
+        echo "\${TRIPLET}"
+    done
+    """
+    platforms = Platform[]
+    for line in split(readchomp(`bash -c $triplets_script`), "\n")
+        if isempty(line) || endswith(line, "gnuassert") || endswith(line, "gnummtk") || endswith(line, "gnuprofiling")
+            continue
+        end
+        try
+            push!(platforms, parse(Platform, line))
+        catch
+            @warn("Couldn't parse $(line) as a platform!")
+        end
+    end
+    return platforms
+end
+
+arches_files = filter(readdir(joinpath(root_dir, "pipelines", "main", "platforms"); join=true)) do fname
+    return endswith(fname, ".arches")
+end
+platforms = unique(vcat(read_arches_file.(arches_files)...))
+
+# Only care about Linux versions, since those are the ones we use to launch jobs
+platforms = filter(Sys.islinux, platforms)
+
+# Collect all versions that have 
+versions = filter(versions_json) do (v, d)
+    if !d["stable"]
+        return false
+    end
+    version_platforms = [parse(Platform, f.triplet) for f in d.files]
+    if any(p ∉ version_platforms for p in platforms)
+        return false
+    end
+    return true
+end
+latest_common_version = maximum(VersionNumber.(String.(collect(keys(versions)))))
+@show latest_common_version


### PR DESCRIPTION
@DilumAluthge @IanButterworth so it appears that the latest version of Julia we have that satisfies armv7l and ppc64le at the same time is 1.6.3, which of course is too old for Sandbox.jl.  Sigh.  So I guess we should just disable either the armv7l or ppc64le bots from doing the generic jobs like upload jobs.