### PR TITLE
Enable debug logging for s3 upload

### DIFF
--- a/utilities/upload_julia.sh
+++ b/utilities/upload_julia.sh
@@ -144,7 +144,7 @@ PIDS=()
 # We'll do these in parallel, then wait on the background jobs
 for SECONDARY_TARGET in ${UPLOAD_TARGETS[@]:1}; do
     for EXT in "${UPLOAD_EXTENSIONS[@]}"; do
-        aws s3 cp --acl public-read "s3://${UPLOAD_TARGETS[0]}.${EXT}" "s3://${SECONDARY_TARGET}.${EXT}" &
+        aws s3 cp --acl public-read "s3://${UPLOAD_TARGETS[0]}.${EXT}" "s3://${SECONDARY_TARGET}.${EXT}" --debug &
         PIDS+=( "$!" )
     done
 done


### PR DESCRIPTION
These upload commands frequently fail on windows. I'm also suspicious that they are taking so long, since they should be server side copies. Enable debug logging to try to gather more info.