### PR TITLE
Don't specify Zstd_jll version on 1.13 because its a stdlib

### DIFF
--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -65,7 +65,12 @@ mktempdir(temp_parent_dir) do dir
     # install a build number that is not the latest build number, you must provide the
     # commit instead of providing the version number.
     Pkg.add(Pkg.PackageSpec(name = "rr_jll", version = "5.8.0", uuid = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"))
-    Pkg.add(Pkg.PackageSpec(name = "Zstd_jll", version = "1.5.0", uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"))
+    # Zstd_jll became a stdlib in Julia 1.13, so we can only use the shipped version
+    if VERSION >= v"1.13.0-0"
+        Pkg.add(Pkg.PackageSpec(name = "Zstd_jll", uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"))
+    else
+        Pkg.add(Pkg.PackageSpec(name = "Zstd_jll", version = "1.5.0", uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"))
+    end
     rr_jll = Base.require(Base.PkgId(Base.UUID("e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"), "rr_jll"))
     zstd_jll = Base.require(Base.PkgId(Base.UUID("3161d3a3-bdf6-5164-811a-617609db77b4"), "Zstd_jll"))
     rr(func) = Base.invokelatest(rr_jll.rr, func; adjust_LIBPATH=false)


### PR DESCRIPTION
Pkg will error now if the requested stdlib version doesn't match the one you'll get, so this needs to be freed on 1.13, which is currently on 1.5.7+1
https://github.com/JuliaLang/Pkg.jl/pull/4335

See failures in https://github.com/JuliaLang/julia/pull/59093