### PR TITLE
Improve timeout scripts to capture more information

### DIFF
--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -95,7 +95,7 @@ mktempdir(temp_parent_dir) do dir
         new_env["JULIA_RR"] = capture_script_path
         t_start = time()
 
-        global proc = run(ignorestatus(setenv(`$(Base.julia_cmd()) $(timeout_script_path) $(rr_path) record --num-cores=$(num_cores) $ARGS`, new_env)))
+        global proc = run(ignorestatus(setenv(`$(Base.julia_cmd()) $(timeout_script_path) --term $(rr_path) record --num-cores=$(num_cores) $ARGS`, new_env)))
         # Wait for `rr` to finish, either through naturally finishing its run, or `SIGTERM`.
         process_failed = !success(proc)
 


### PR DESCRIPTION
- Switch rr ones back to SIGTERM, to actually terminate recording gracefully
- On Linux, when SIGQUIT'ing walk the process tree to try to get coredumps from each stuck process, rather than just the toplevel (which is often just waiting for a worker).

Written by Claude.