### PR TITLE
Try running tests in their own session id

### DIFF
--- a/utilities/proc_utils.jl
+++ b/utilities/proc_utils.jl
@@ -30,3 +30,4 @@ function get_bool_from_env(name::AbstractString, default_value::Bool)
 end
 
 const is_buildkite = get_bool_from_env("BUILDKITE", false)
+const Cpid_t = Int32

--- a/utilities/rr/rr_capture.jl
+++ b/utilities/rr/rr_capture.jl
@@ -93,6 +93,7 @@ mktempdir(temp_parent_dir) do dir
         new_env["RR_UNDER_RR_LOG"] = "all:debug"
         new_env["RR_LOG_BUFFER"] = "100000"
         new_env["JULIA_RR"] = capture_script_path
+        new_env["JL_TERM_SIGTERM"] = "true"
         t_start = time()
 
         global proc = run(ignorestatus(setenv(`$(Base.julia_cmd()) $(timeout_script_path) $(rr_path) record --num-cores=$(num_cores) $ARGS`, new_env)))

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -49,6 +49,12 @@ export JULIA_TEST_IS_BASE_CI="true"
 unset JULIA_DEPOT_PATH
 unset JULIA_PKG_SERVER
 
+if [[ "${OS}" != "windows" ]]; then
+    # Tell timeout.jl to detach the process group, so we get core dumps from
+    # each process.
+    export JL_TERM_DETACH="true"
+fi
+
 # Make sure that temp files and temp directories are created in a location that is
 # backed by real storage, and not by a tmpfs, as some tests don't like that on Linux
 if [[ "${OS}" == "linux" ]]; then


### PR DESCRIPTION
Alternative to https://github.com/JuliaCI/julia-buildkite/pull/465. I think it might be even better to just do `setpgid(0, 0)`, but libuv doesn't support that natively. Let's see if `setsid` works.