### PR TITLE
Upload `dmesg` log for failed Unix builds (e.g. to look for evidence of the OOM killer)

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -210,4 +210,12 @@ else
 fi
 echo "--- Done"
 
+if [[ "${exitVal}" -ne 0 ]] && [[ "${OS}" == linux* || "${OS}" == "musl" || "${OS}" == "freebsd" ]]; then
+    echo "--- Upload dmesg to diagnose potential OOM killer activity"
+    dmesg > dmesg.log 2>&1 || true
+    if [[ -s dmesg.log ]]; then
+        buildkite-agent artifact upload dmesg.log || true
+    fi
+fi
+
 exit $exitVal

--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -212,7 +212,7 @@ echo "--- Done"
 
 if [[ "${exitVal}" -ne 0 ]] && [[ "${OS}" == linux* || "${OS}" == "musl" || "${OS}" == "freebsd" ]]; then
     echo "--- Upload dmesg to diagnose potential OOM killer activity"
-    dmesg > dmesg.log 2>&1 || true
+    dmesg > dmesg.log || true
     if [[ -s dmesg.log ]]; then
         buildkite-agent artifact upload dmesg.log || true
     fi


### PR DESCRIPTION
The idea is that if e.g. the OOM killer is active, we can see evidence of that in the dmesg logs. Written by Claude.