### PR TITLE
Add JuliaC.jl test pipeline for all supported platforms

### DIFF
--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -115,6 +115,7 @@ steps:
           export ALLOW_FAIL="false"
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/gcext.yml
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/test_revise.yml
+          buildkite-agent pipeline upload .buildkite/pipelines/main/misc/juliac/test_juliac.yml
 
           ### Launch Linux test jobs.
           # Regular:

--- a/pipelines/main/misc/juliac/test_juliac.yml
+++ b/pipelines/main/misc/juliac/test_juliac.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "JuliaC"
     steps:
       - label: "Launch JuliaC test jobs"
         plugins:
@@ -9,17 +9,17 @@ steps:
         commands: |
           export ALLOW_FAIL="${ALLOW_FAIL:-false}"
           ### Launch Linux JuliaC test jobs:
-          GROUP="Test" \
+          GROUP="JuliaC" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/misc/juliac/test_juliac_linux.arches \
               .buildkite/pipelines/main/misc/juliac/test_juliac_linux.yml
           ### Launch macOS JuliaC test jobs:
-          GROUP="Test" \
+          GROUP="JuliaC" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/misc/juliac/test_juliac_macos.arches \
               .buildkite/pipelines/main/misc/juliac/test_juliac_macos.yml
           ### Launch Windows JuliaC test jobs:
-          GROUP="Test" \
+          GROUP="JuliaC" \
               bash .buildkite/utilities/arches_pipeline_upload.sh \
               .buildkite/pipelines/main/misc/juliac/test_juliac_windows.arches \
               .buildkite/pipelines/main/misc/juliac/test_juliac_windows.yml

--- a/pipelines/main/misc/juliac/test_juliac.yml
+++ b/pipelines/main/misc/juliac/test_juliac.yml
@@ -1,0 +1,29 @@
+steps:
+  - group: "Test"
+    steps:
+      - label: "Launch JuliaC test jobs"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          export ALLOW_FAIL="${ALLOW_FAIL:-false}"
+          ### Launch Linux JuliaC test jobs:
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_linux.arches \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_linux.yml
+          ### Launch macOS JuliaC test jobs:
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_macos.arches \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_macos.yml
+          ### Launch Windows JuliaC test jobs:
+          GROUP="Test" \
+              bash .buildkite/utilities/arches_pipeline_upload.sh \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_windows.arches \
+              .buildkite/pipelines/main/misc/juliac/test_juliac_windows.yml
+        agents:
+          queue: "julia"
+          os: "linux"
+          arch: "x86_64"

--- a/pipelines/main/misc/juliac/test_juliac_linux.arches
+++ b/pipelines/main/misc/juliac/test_juliac_linux.arches
@@ -1,6 +1,6 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                  ARCH       ARCH_ROOTFS    TIMEOUT    ROOTFS_TAG    ROOTFS_HASH                                  ALLOW_FAIL
-tester_linux           x86_64-linux-gnu         x86_64     x86_64         .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f     .
-tester_linux           aarch64-linux-gnu        aarch64    aarch64        .          v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b     true
+package_linux          x86_64-linux-gnu         x86_64     x86_64         .          v7.3          d8de9e0051c5cd69f3dde8ddaefc594d0a71043b     .
+package_linux          aarch64-linux-gnu        aarch64    aarch64        .          v7.3          d39fb11781df9b03e448ad9318df2d195a3acf26     true
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string

--- a/pipelines/main/misc/juliac/test_juliac_linux.arches
+++ b/pipelines/main/misc/juliac/test_juliac_linux.arches
@@ -1,5 +1,5 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                  ARCH       ARCH_ROOTFS    TIMEOUT    ROOTFS_TAG    ROOTFS_HASH                                  ALLOW_FAIL
-package_linux          x86_64-linux-gnu         x86_64     x86_64         .          v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc     .
+tester_linux           x86_64-linux-gnu         x86_64     x86_64         .          v6.00         770c0240be788cfeb9654e1980ea929d3ed98d1f     .
 tester_linux           aarch64-linux-gnu        aarch64    aarch64        .          v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b     true
 
 # These special lines allow us to embed default values for the columns above.

--- a/pipelines/main/misc/juliac/test_juliac_linux.arches
+++ b/pipelines/main/misc/juliac/test_juliac_linux.arches
@@ -1,0 +1,8 @@
+# ROOTFS_IMAGE_NAME    TRIPLET                  ARCH       ARCH_ROOTFS    TIMEOUT    ROOTFS_TAG    ROOTFS_HASH
+package_linux          x86_64-linux-gnu         x86_64     x86_64         .          v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
+tester_linux           aarch64-linux-gnu        aarch64    aarch64        .          v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+#default TIMEOUT 30

--- a/pipelines/main/misc/juliac/test_juliac_linux.arches
+++ b/pipelines/main/misc/juliac/test_juliac_linux.arches
@@ -1,8 +1,9 @@
-# ROOTFS_IMAGE_NAME    TRIPLET                  ARCH       ARCH_ROOTFS    TIMEOUT    ROOTFS_TAG    ROOTFS_HASH
-package_linux          x86_64-linux-gnu         x86_64     x86_64         .          v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc
-tester_linux           aarch64-linux-gnu        aarch64    aarch64        .          v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b
+# ROOTFS_IMAGE_NAME    TRIPLET                  ARCH       ARCH_ROOTFS    TIMEOUT    ROOTFS_TAG    ROOTFS_HASH                                  ALLOW_FAIL
+package_linux          x86_64-linux-gnu         x86_64     x86_64         .          v6.00         4dcde853eb5baaa0a8f087b633eaf955dc94b5dc     .
+tester_linux           aarch64-linux-gnu        aarch64    aarch64        .          v6.00         4efb2a7f62f668ef08633579bfbfe1e5e4b2969b     true
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string
 
 #default TIMEOUT 30
+#default ALLOW_FAIL false

--- a/pipelines/main/misc/juliac/test_juliac_linux.yml
+++ b/pipelines/main/misc/juliac/test_juliac_linux.yml
@@ -9,10 +9,6 @@ steps:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
-          - JuliaCI/julia#v1:
-              # Drop default "registries" directory, so it is not persisted from execution to execution
-              persist_depot_dirs: packages,artifacts,compiled
-              version: '1.11' # GREP_ME: Keep this updated. Do not set it to '1' or 'stable' or 'latest'.
           - staticfloat/sandbox#v2:
               rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/${ROOTFS_TAG?}/${ROOTFS_IMAGE_NAME?}.${ARCH_ROOTFS?}.tar.gz
               rootfs_treehash: "${ROOTFS_HASH?}"

--- a/pipelines/main/misc/juliac/test_juliac_linux.yml
+++ b/pipelines/main/misc/juliac/test_juliac_linux.yml
@@ -1,0 +1,40 @@
+steps:
+  - group: "Test"
+    steps:
+      - label: ":linux: test JuliaC ${TRIPLET?}"
+        key: "test-juliac-${TRIPLET?}"
+        depends_on:
+          - "build_${TRIPLET?}"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              # Drop default "registries" directory, so it is not persisted from execution to execution
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.11' # GREP_ME: Keep this updated. Do not set it to '1' or 'stable' or 'latest'.
+          - staticfloat/sandbox#v2:
+              rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/${ROOTFS_TAG?}/${ROOTFS_IMAGE_NAME?}.${ARCH_ROOTFS?}.tar.gz
+              rootfs_treehash: "${ROOTFS_HASH?}"
+              uid: 1000
+              gid: 1000
+              workspaces:
+                # Include `/cache/repos` so that our `git` version introspection works.
+                - "/cache/repos:/cache/repos"
+        commands: |
+          # Download pre-built julia, extract into `usr/`
+          buildkite-agent artifact download --step "build_${TRIPLET}" 'julia-*-linux-*.tar.gz' .
+          mkdir -p ./usr
+          tar -C ./usr --strip-components=1 -zxf julia-*-linux-*.tar.gz
+          ln -s ./usr/bin/julia ./julia
+
+          echo "--- Install and test JuliaC"
+          unset JULIA_DEPOT_PATH
+          JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+        timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
+        agents:
+          queue: "julia"
+          sandbox_capable: "true"
+          os: "linux"
+          arch: "${ARCH?}"

--- a/pipelines/main/misc/juliac/test_juliac_linux.yml
+++ b/pipelines/main/misc/juliac/test_juliac_linux.yml
@@ -9,6 +9,9 @@ steps:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.11' # GREP_ME: Keep this updated. Do not set it to '1' or 'stable' or 'latest'.
           - staticfloat/sandbox#v2:
               rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/${ROOTFS_TAG?}/${ROOTFS_IMAGE_NAME?}.${ARCH_ROOTFS?}.tar.gz
               rootfs_treehash: "${ROOTFS_HASH?}"

--- a/pipelines/main/misc/juliac/test_juliac_linux.yml
+++ b/pipelines/main/misc/juliac/test_juliac_linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "${GROUP?}"
     steps:
       - label: ":linux: test JuliaC ${TRIPLET?}"
         key: "test-juliac-${TRIPLET?}"

--- a/pipelines/main/misc/juliac/test_juliac_linux.yml
+++ b/pipelines/main/misc/juliac/test_juliac_linux.yml
@@ -30,7 +30,11 @@ steps:
 
           echo "--- Install and test JuliaC"
           unset JULIA_DEPOT_PATH
-          JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          if [ -f deps/jlutilities/juliac/Manifest.toml ]; then
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.activate("deps/jlutilities/juliac"); Pkg.instantiate(); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          else
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          fi
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: ${ALLOW_FAIL?}
         agents:

--- a/pipelines/main/misc/juliac/test_juliac_macos.arches
+++ b/pipelines/main/misc/juliac/test_juliac_macos.arches
@@ -1,0 +1,8 @@
+# OS       TRIPLET                  ARCH          TIMEOUT
+macos      x86_64-apple-darwin      x86_64        .
+macos      aarch64-apple-darwin     aarch64       .
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+#default TIMEOUT 30

--- a/pipelines/main/misc/juliac/test_juliac_macos.yml
+++ b/pipelines/main/misc/juliac/test_juliac_macos.yml
@@ -1,0 +1,30 @@
+steps:
+  - group: "Test"
+    steps:
+      - label: ":macos: test JuliaC ${TRIPLET?}"
+        key: "test-juliac-${TRIPLET?}"
+        depends_on:
+          - "build_${TRIPLET?}"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          # Download pre-built julia, extract into `usr/`
+          buildkite-agent artifact download --step "build_${TRIPLET}" 'julia-*-macos-*.tar.gz' .
+          mkdir -p ./usr
+          tar -C ./usr --strip-components=1 -zxf julia-*-macos-*.tar.gz
+          ln -s ./usr/bin/julia ./julia
+
+          # Re-sign after download
+          .buildkite/utilities/macos/codesign.sh ./usr
+
+          echo "--- Install and test JuliaC"
+          unset JULIA_DEPOT_PATH
+          JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+        timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
+        agents:
+          queue: "julia"
+          os: "macos"
+          arch: "${ARCH}"

--- a/pipelines/main/misc/juliac/test_juliac_macos.yml
+++ b/pipelines/main/misc/juliac/test_juliac_macos.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "${GROUP?}"
     steps:
       - label: ":macos: test JuliaC ${TRIPLET?}"
         key: "test-juliac-${TRIPLET?}"

--- a/pipelines/main/misc/juliac/test_juliac_macos.yml
+++ b/pipelines/main/misc/juliac/test_juliac_macos.yml
@@ -21,7 +21,11 @@ steps:
 
           echo "--- Install and test JuliaC"
           unset JULIA_DEPOT_PATH
-          JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          if [ -f deps/jlutilities/juliac/Manifest.toml ]; then
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.activate("deps/jlutilities/juliac"); Pkg.instantiate(); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          else
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./julia -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          fi
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: ${ALLOW_FAIL?}
         agents:

--- a/pipelines/main/misc/juliac/test_juliac_windows.arches
+++ b/pipelines/main/misc/juliac/test_juliac_windows.arches
@@ -1,0 +1,7 @@
+# OS       TRIPLET                ARCH          TIMEOUT
+windows    x86_64-w64-mingw32     x86_64        .
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+#default TIMEOUT 30

--- a/pipelines/main/misc/juliac/test_juliac_windows.yml
+++ b/pipelines/main/misc/juliac/test_juliac_windows.yml
@@ -1,0 +1,25 @@
+steps:
+  - group: "Test"
+    steps:
+      - label: ":windows: test JuliaC ${TRIPLET?}"
+        key: "test-juliac-${TRIPLET?}"
+        depends_on:
+          - "build_${TRIPLET?}"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          # Download pre-built julia, extract into `usr/`
+          buildkite-agent artifact download --step "build_${TRIPLET}" 'julia-*-windows-*.tar.gz' .
+          mkdir -p ./usr
+          tar -C ./usr --strip-components=1 -zxf julia-*-windows-*.tar.gz
+          echo "--- Install and test JuliaC"
+          unset JULIA_DEPOT_PATH
+          JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+        timeout_in_minutes: ${TIMEOUT?}
+        soft_fail: ${ALLOW_FAIL?}
+        agents:
+          queue: "julia"
+          os: "windows"
+          arch: "${ARCH}"

--- a/pipelines/main/misc/juliac/test_juliac_windows.yml
+++ b/pipelines/main/misc/juliac/test_juliac_windows.yml
@@ -1,5 +1,5 @@
 steps:
-  - group: "Test"
+  - group: "${GROUP?}"
     steps:
       - label: ":windows: test JuliaC ${TRIPLET?}"
         key: "test-juliac-${TRIPLET?}"

--- a/pipelines/main/misc/juliac/test_juliac_windows.yml
+++ b/pipelines/main/misc/juliac/test_juliac_windows.yml
@@ -16,7 +16,11 @@ steps:
           tar -C ./usr --strip-components=1 -zxf julia-*-windows-*.tar.gz
           echo "--- Install and test JuliaC"
           unset JULIA_DEPOT_PATH
-          JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          if [ -f deps/jlutilities/juliac/Manifest.toml ]; then
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.activate("deps/jlutilities/juliac"); Pkg.instantiate(); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          else
+            JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+          fi
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: ${ALLOW_FAIL?}
         agents:


### PR DESCRIPTION
## Summary
- Add CI pipeline to test JuliaC.jl on all supported architectures: Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
- Uses the arches pipeline pattern (like the main test suite) for multi-platform dispatch
- Each job downloads the pre-built Julia from the corresponding build step, installs JuliaC.jl from `main`, and runs `Pkg.test("JuliaC")`

## Test plan
- [ ] Verify pipeline uploads correctly on a test build
- [ ] Confirm artifact download works for each platform/arch combination
- [ ] Check that JuliaC.jl tests pass on all 5 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)