### PR TITLE
Windows: Update the Docker images from v7.10 to v8.1 (to use the correct CMake)

### DIFF
--- a/pipelines/main/platforms/build_windows.arches
+++ b/pipelines/main/platforms/build_windows.arches
@@ -1,6 +1,6 @@
 # OS     TRIPLET              ARCH       DOCKER_ARCH   MAKE_FLAGS                                                                                                                                                                                                                                        TIMEOUT     DOCKER_TAG
-windows  x86_64-w64-mingw32   x86_64     x86_64        VERBOSE=1,JL_CFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion",JL_CXXFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion"                                 .           v7.10
-windows  i686-w64-mingw32     x86_64     i686          VERBOSE=1,JL_CFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion",JL_CXXFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion"                                 .           v7.10
+windows  x86_64-w64-mingw32   x86_64     x86_64        VERBOSE=1,JL_CFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion",JL_CXXFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion"                                 .           v8.1
+windows  i686-w64-mingw32     x86_64     i686          VERBOSE=1,JL_CFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion",JL_CXXFLAGS="-Werror -Wno-error=array-bounds -Wno-error=array-bounds= -Wno-error=infinite-recursion"                                 .           v8.1
 
 # These special lines allow us to embed default values for the columns above.
 # Any column without a default mapping here will simply substitute a `.` to the empty string


### PR DESCRIPTION
https://github.com/JuliaCI/rootfs-images/releases/tag/v8.1

Changelog: https://github.com/JuliaCI/rootfs-images/compare/v7.10...v8.1

@Keno: This includes your CMake fix (https://github.com/JuliaCI/rootfs-images/pull/264).