### PR TITLE
[DO NOT MERGE] Debug `JuliaC` failures on `rhea`

### DIFF
--- a/pipelines/main/misc/juliac/test_juliac_windows.yml
+++ b/pipelines/main/misc/juliac/test_juliac_windows.yml
@@ -16,10 +16,12 @@ steps:
           tar -C ./usr --strip-components=1 -zxf julia-*-windows-*.tar.gz
           echo "--- Install and test JuliaC"
           unset JULIA_DEPOT_PATH
+          echo "--- Diagnostics"
+          ./usr/bin/julia.exe -e 'println("CPU_NAME:   ", Sys.CPU_NAME); println("cpu_target: ", unsafe_string(Base.JLOptions().cpu_target)); println("CacheFlags: ", Base.CacheFlags()); println("image_file: ", unsafe_string(Base.JLOptions().image_file)); println("BINDIR:     ", Sys.BINDIR)'
           if [ -f deps/jlutilities/juliac/Manifest.toml ]; then
-            JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.activate("deps/jlutilities/juliac"); Pkg.instantiate(); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+            JULIA_DEBUG=loading JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.activate("deps/jlutilities/juliac"); Pkg.instantiate(); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
           else
-            JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
+            JULIA_DEBUG=loading JULIA_PKG_PRECOMPILE_AUTO=0 ./usr/bin/julia.exe -e 'using Pkg; Pkg.add(name="JuliaC", rev="main"); ENV["JULIA_PKG_PRECOMPILE_AUTO"]=1; Pkg.test("JuliaC")'
           fi
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: ${ALLOW_FAIL?}


### PR DESCRIPTION
Investigating failures like https://buildkite.com/julialang/julia-master/builds/56664/steps/canvas?jid=019dae18-6ba9-4eef-84c4-847a0388e9a0&tab=output#019dae18-6ba9-4eef-84c4-847a0388e9a0, which seem to be specific to the `rhea` agents