### PR TITLE
Change MMTk CI to use StickyImmix

### DIFF
--- a/pipelines/main/platforms/build_linux.soft_fail.arches
+++ b/pipelines/main/platforms/build_linux.soft_fail.arches
@@ -1,6 +1,6 @@
 # ROOTFS_IMAGE_NAME    TRIPLET                   ARCH           ARCH_ROOTFS    MAKE_FLAGS                               TIMEOUT     ROOTFS_TAG    ROOTFS_HASH
 # package_musl           x86_64-linux-musl         x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror    .           v7.6          ee00851bfbd742f895a7c5c94d5369abe88ffcbc
-package_linux_mmtk     x86_64-linux-gnummtk           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror,WITH_THIRD_PARTY_GC=mmtk,MMTK_PLAN=Immix,MMTK_MOVING=0    .             v8.5          27c85eb02722ba43b1acac8417305e2e31dd55ad
+package_linux_mmtk     x86_64-linux-gnummtk           x86_64         x86_64         JL_CFLAGS=-Werror,JL_CXXFLAGS=-Werror,WITH_THIRD_PARTY_GC=mmtk,MMTK_PLAN=StickyImmix,MMTK_MOVING=0    .             v8.5          27c85eb02722ba43b1acac8417305e2e31dd55ad
 # package_linux        armv7l-linux-gnueabihf    armv7l         armv7l         .                                        .           ----          ----------------------------------------
 
 

--- a/utilities/extract_triplet.sh
+++ b/utilities/extract_triplet.sh
@@ -23,7 +23,7 @@ case "${TRIPLET}" in
     *-gnuprofiling) # profiling-enabled builds (`WITH_TRACY=1` and `WITH_ITTAPI=1` and `WITH_TIMING_COUNTS=1`)
         OS="linuxprofiling"
         ;;
-    *-gnummtk) # Using MMTk Immix as the default GC (`MMTK_PLAN=Immix`)
+    *-gnummtk) # Using MMTk StickyImmix as the default GC (`MMTK_PLAN=StickyImmix`)
         OS="linuxmmtk"
         ;;
     *-gnusrcassert) # both "from source" and assert


### PR DESCRIPTION
This PR changes the GC plan to run for MMTk from Immix to StickyImmix (generational).