### PR TITLE
Put 'launch' jobs on the build queue.

### DIFF
--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -66,7 +66,7 @@ steps:
               .buildkite/pipelines/main/platforms/build_windows.arches \
               .buildkite/pipelines/main/platforms/build_windows.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Check"
@@ -98,7 +98,7 @@ steps:
             echo "./JuliaSyntax/Project.toml file does NOT exist. Will not launch JuliaSyntax test jobs"
           fi
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Test"
@@ -145,7 +145,7 @@ steps:
               .buildkite/pipelines/main/platforms/test_windows.yml
           echo "+++ Finished launching test jobs"
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Allow Fail"
@@ -168,7 +168,7 @@ steps:
               .buildkite/pipelines/main/platforms/build_macos.soft_fail.arches \
               .buildkite/pipelines/main/platforms/build_macos.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
       - label: "Launch allowed-to-fail test jobs"
@@ -216,6 +216,6 @@ steps:
               .buildkite/pipelines/main/platforms/test_windows.soft_fail.arches \
               .buildkite/pipelines/main/platforms/test_windows.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots

--- a/pipelines/main/misc/juliasyntax.launch.yml
+++ b/pipelines/main/misc/juliasyntax.launch.yml
@@ -26,6 +26,6 @@ steps:
         commands: |
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/juliasyntax.test.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots

--- a/pipelines/scheduled/launch_unsigned_jobs.yml
+++ b/pipelines/scheduled/launch_unsigned_jobs.yml
@@ -27,7 +27,7 @@ steps:
               .buildkite/pipelines/scheduled/platforms/build_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Source Tests (Allow Fail)"
@@ -44,7 +44,7 @@ steps:
               .buildkite/pipelines/scheduled/platforms/test_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "no_GPL"
@@ -71,6 +71,6 @@ steps:
               .buildkite/pipelines/scheduled/platforms/build_windows.no_gpl.arches \
               .buildkite/pipelines/main/platforms/build_windows.yml
         agents:
-          queue: "test"
+          queue: "build"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots


### PR DESCRIPTION
The `test` queue is pretty oversubscribed.

We should probably introduce a low-latency `launch` queue at some point.