### PR TITLE
test_julia: skip JuliaLowering_stdlibs under rr

### DIFF
--- a/utilities/test_julia.sh
+++ b/utilities/test_julia.sh
@@ -83,8 +83,8 @@ if [[ "${USE_RR-}" == "rr" ]] || [[ "${USE_RR-}" == "rr-net" ]]; then
     export NCORES_FOR_TESTS="parse(Int, ENV[\"JULIA_RRCAPTURE_NUM_CORES\"])"
     export JULIA_NUM_THREADS=1
 
-    # Do not run Pkg tests on rr
-    TESTS_TO_SKIP+=( Pkg )
+    # Do not run Pkg or JuliaLowering stdlib tests on rr.
+    TESTS_TO_SKIP+=( Pkg JuliaLowering_stdlibs )
 
     # rr: all tests EXCEPT the network-related tests
     # rr-net: ONLY the network-related tests


### PR DESCRIPTION
The `gnuassrtrr` test job (x86_64-linux-gnuassert, run under rr) times out at its 6h Buildkite limit. The dominant cost is the JuliaLowering_stdlibs test, which precompiles every stdlib in two cache configurations using the pure-Julia JuliaLowering frontend. That workload is embarrassingly parallel, but rr records deterministically and serializes it onto effectively one core, so it took 2h45m in build 58055 (vs ~3min without rr) and was the long pole gating the entire parallel test phase, pushing the job past its timeout.