### PR TITLE
Backport CI rework to 1.10: split the `julia` queue (+ cygwin fix)

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -29,10 +29,37 @@ if [[ "${DISABLE_UPSTREAM_CACHE}" != "true" ]]; then
         git -C "${UPSTREAM_CACHE}" fetch
     fi
 fi
-
 # Clear out current directory
 # The deliciously complicated `rm` invocation is thanks to https://unix.stackexchange.com/a/77313/29688
-rm -rf ..?* .[!.]* *
+if [[ "${OSTYPE:-}" == "msys"* || "${OSTYPE:-}" == "cygwin"* ]]; then
+    # On Windows a just-checked-out file is intermittently still held open by
+    # another process *without* FILE_SHARE_DELETE, so `rm` dies on
+    # `.buildkite/hooks/post-checkout` with "Device or resource busy".  The
+    # holder is transient (build jobs that spend ~2.5 min cloning the Julia
+    # mirror first always get past it), and `rm` deletes everything it CAN on
+    # each pass, so just retry until the file is gone.  We can't tolerate a
+    # leftover: a non-empty `.buildkite/` makes the external-buildkite plugin's
+    # later `git clone ... .buildkite` fail.  (mv/rename of the file fares worse
+    # than delete here, so don't go that route.)
+    rm -rf ..?* .[!.]* * 2>/dev/null || true
+    if [[ -e .buildkite/hooks/post-checkout ]]; then
+        # One-shot diagnostic: who is holding it open?  (best-effort)
+        echo "--- post-checkout busy after first rm; handle holders:"
+        handle64.exe -accepteula -nobanner post-checkout 2>&1 \
+            || handle.exe -accepteula -nobanner post-checkout 2>&1 || true
+    fi
+    deadline=$(( SECONDS + 300 ))
+    while [[ -e .buildkite/hooks/post-checkout ]]; do
+        if (( SECONDS >= deadline )); then
+            echo "ERROR: .buildkite/hooks/post-checkout still held open after 300s" >&2
+            exit 1
+        fi
+        sleep 2
+        rm -rf ..?* .[!.]* * 2>/dev/null || true
+    done
+else
+    rm -rf ..?* .[!.]* *
+fi
 
 # git clone, then force checkout the given gitref
 UPSTREAM_GITREF="$(buildkite-agent meta-data get --default "origin/${UPSTREAM_BRANCH}" BUILDKITE_JULIA_VERSION)"

--- a/pipelines/main/0_webui.yml
+++ b/pipelines/main/0_webui.yml
@@ -6,7 +6,7 @@ steps:
     steps:
       - label: "Unlock secrets, launch pipelines"
         agents:
-          queue: "julia"
+          queue: "launch"
           cryptic_capable: "true"
           os: "linux"
         plugins:

--- a/pipelines/main/launch_signed_jobs.yml
+++ b/pipelines/main/launch_signed_jobs.yml
@@ -34,7 +34,7 @@ steps:
                     - .buildkite/pipelines/main/misc/upload_buildkite_results.yml
         agents:
           cryptic_capable: "true"
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
         env:

--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -23,7 +23,7 @@ steps:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
-          - JuliaCI/julia#b4d0bfa510bc399417133adae013385af5c71190: # v1.13.5
+          - JuliaCI/julia#d8cd48ed4e72ca4ea47a5d02d79fb1bea0ee3e6b: # v1.13.8
               # A few notes:
               # 1. We pin the `JuliaCI/julia` plugin to a full commit hash.
               #    This is intentional. We want to make sure that this script doesn't suddenly
@@ -167,7 +167,7 @@ steps:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
-          - JuliaCI/julia#b4d0bfa510bc399417133adae013385af5c71190: # v1.13.5
+          - JuliaCI/julia#d8cd48ed4e72ca4ea47a5d02d79fb1bea0ee3e6b: # v1.13.8
               # A few notes:
               # 1. We pin the `JuliaCI/julia` plugin to a full commit hash.
               #    This is intentional. We want to make sure that this script doesn't suddenly

--- a/pipelines/main/launch_unsigned_jobs.yml
+++ b/pipelines/main/launch_unsigned_jobs.yml
@@ -66,7 +66,7 @@ steps:
               .buildkite/pipelines/main/platforms/build_windows.arches \
               .buildkite/pipelines/main/platforms/build_windows.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Check"
@@ -90,7 +90,7 @@ steps:
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/sanitizers/asan.yml
           buildkite-agent pipeline upload .buildkite/pipelines/main/misc/sanitizers/tsan.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Test"
@@ -136,7 +136,7 @@ steps:
               .buildkite/pipelines/main/platforms/test_windows.yml
           echo "+++ Finished launching test jobs"
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Allow Fail"
@@ -159,7 +159,7 @@ steps:
               .buildkite/pipelines/main/platforms/build_macos.soft_fail.arches \
               .buildkite/pipelines/main/platforms/build_macos.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
       - label: "Launch allowed-to-fail test jobs"
@@ -207,6 +207,6 @@ steps:
               .buildkite/pipelines/main/platforms/test_windows.soft_fail.arches \
               .buildkite/pipelines/main/platforms/test_windows.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots

--- a/pipelines/main/launch_upload_jobs.yml
+++ b/pipelines/main/launch_upload_jobs.yml
@@ -8,7 +8,7 @@ steps:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
-          - JuliaCI/julia#b4d0bfa510bc399417133adae013385af5c71190: # v1.13.5
+          - JuliaCI/julia#d8cd48ed4e72ca4ea47a5d02d79fb1bea0ee3e6b: # v1.13.8
               # A few notes:
               # 1. We pin the `JuliaCI/julia` plugin to a full commit hash.
               #    This is intentional. We want to make sure that this script doesn't suddenly

--- a/pipelines/main/launch_upload_jobs.yml
+++ b/pipelines/main/launch_upload_jobs.yml
@@ -66,7 +66,7 @@ steps:
           unset BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET
         agents:
           cryptic_capable: "true"
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
         env:
@@ -95,7 +95,7 @@ steps:
           unset BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET
         agents:
           cryptic_capable: "true"
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
         env:

--- a/pipelines/main/misc/analyzegc.yml
+++ b/pipelines/main/misc/analyzegc.yml
@@ -25,7 +25,7 @@ steps:
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C src analyze --keep-going
         timeout_in_minutes: 60
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/deploy_docs.yml
+++ b/pipelines/main/misc/deploy_docs.yml
@@ -77,7 +77,7 @@ steps:
           fi
         timeout_in_minutes: 45
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/doctest.yml
+++ b/pipelines/main/misc/doctest.yml
@@ -46,7 +46,7 @@ steps:
           DOCUMENTER_KEY: ""
         timeout_in_minutes: 45
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           doctest_capable: "true"
           os: "linux"

--- a/pipelines/main/misc/embedding.yml
+++ b/pipelines/main/misc/embedding.yml
@@ -34,7 +34,7 @@ steps:
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C test/embedding check JULIA="$$(pwd)/usr/bin/julia" BIN="$${embedding_output:?}"
         timeout_in_minutes: 60
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/gcext.yml
+++ b/pipelines/main/misc/gcext.yml
@@ -35,7 +35,7 @@ steps:
         timeout_in_minutes: 60
         soft_fail: ${ALLOW_FAIL?}
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/llvmpasses.yml
+++ b/pipelines/main/misc/llvmpasses.yml
@@ -30,7 +30,7 @@ steps:
           make --output-sync -j$${JULIA_CPU_THREADS:?} -C test/llvmpasses $${MAKE_ASSERT_FLAGS:?}
         timeout_in_minutes: 60
         agents:
-          queue: "julia"
+          queue: "build"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/pdf_docs/build_pdf_docs.yml
+++ b/pipelines/main/misc/pdf_docs/build_pdf_docs.yml
@@ -45,7 +45,7 @@ steps:
           cd doc/_build/pdf/en && buildkite-agent artifact upload TheJuliaLanguage.pdf
         timeout_in_minutes: 120
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/sanitizers/asan.yml
+++ b/pipelines/main/misc/sanitizers/asan.yml
@@ -25,7 +25,7 @@ steps:
         echo "--- Build julia with ASAN"
         VERBOSE=1 contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_CPU_THREADS:?}
       agents:
-        queue: "julia"
+        queue: "build"
         sandbox_capable: "true"
         os: "linux"
         arch: "x86_64"

--- a/pipelines/main/misc/sanitizers/tsan.yml
+++ b/pipelines/main/misc/sanitizers/tsan.yml
@@ -22,7 +22,7 @@ steps:
         echo "--- Build julia-debug runtime with TSAN"
         VERBOSE=1 contrib/tsan/build.sh ./tmp/test-tsan -j$${JULIA_CPU_THREADS:?} julia-src-debug
       agents:
-        queue: "julia"
+        queue: "build"
         sandbox_capable: "true"
         os: "linux"
         arch: "x86_64"

--- a/pipelines/main/misc/test_revise.yml
+++ b/pipelines/main/misc/test_revise.yml
@@ -34,7 +34,7 @@ steps:
         timeout_in_minutes: 30
         soft_fail: ${ALLOW_FAIL?}
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "x86_64"

--- a/pipelines/main/misc/upload_buildkite_results.yml
+++ b/pipelines/main/misc/upload_buildkite_results.yml
@@ -67,7 +67,7 @@ steps:
             echo ""
           done
         agents:
-          queue: "julia"
+          queue: "test"
         env:
           # Receive cryptic token from parent job
           BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET: ${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET?}

--- a/pipelines/main/misc/whitespace.yml
+++ b/pipelines/main/misc/whitespace.yml
@@ -27,7 +27,7 @@ steps:
         commands: |
           make --output-sync -j$${JULIA_CPU_THREADS:?} check-whitespace
         agents:
-          queue: "julia"
+          queue: "test"
           # Only run on `sandbox.jl`-capable machines (not `docker`-isolated ones) since we need nestable sandboxing
           sandbox_capable: "true"
           os: "linux"

--- a/pipelines/main/platforms/build_freebsd.yml
+++ b/pipelines/main/platforms/build_freebsd.yml
@@ -11,7 +11,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/build_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           os: "freebsd"
           arch: "${ARCH?}"
         env:

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -23,7 +23,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/build_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
           sandbox_capable: "true"
           os: "linux"

--- a/pipelines/main/platforms/build_macos.yml
+++ b/pipelines/main/platforms/build_macos.yml
@@ -11,7 +11,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/build_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           os: "macos"
           arch: "${ARCH?}"
         env:

--- a/pipelines/main/platforms/build_windows.yml
+++ b/pipelines/main/platforms/build_windows.yml
@@ -25,7 +25,7 @@ steps:
         timeout_in_minutes: ${TIMEOUT?}
         soft_fail: ${ALLOW_FAIL?}
         agents:
-          queue: "julia"
+          queue: "build"
           os: "windows"
           arch: "${ARCH?}"
         env:

--- a/pipelines/main/platforms/test_freebsd.yml
+++ b/pipelines/main/platforms/test_freebsd.yml
@@ -18,7 +18,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/test_julia.sh"
         agents:
-          queue: "julia"
+          queue: "test"
           os: "freebsd"
           arch: "${ARCH}"
         env:

--- a/pipelines/main/platforms/test_linux.i686.yml
+++ b/pipelines/main/platforms/test_linux.i686.yml
@@ -32,7 +32,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/test_julia.sh"
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "${ARCH?}"

--- a/pipelines/main/platforms/test_linux.yml
+++ b/pipelines/main/platforms/test_linux.yml
@@ -32,7 +32,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/test_julia.sh"
         agents:
-          queue: "julia"
+          queue: "test"
           sandbox_capable: "true"
           os: "linux"
           arch: "${ARCH?}"

--- a/pipelines/main/platforms/test_macos.yml
+++ b/pipelines/main/platforms/test_macos.yml
@@ -19,7 +19,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/test_julia.sh"
         agents:
-          queue: "julia"
+          queue: "test"
           os: "macos"
           arch: "${ARCH}"
         env:

--- a/pipelines/main/platforms/test_windows.yml
+++ b/pipelines/main/platforms/test_windows.yml
@@ -13,7 +13,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/test_julia.sh"
         agents:
-          queue: "julia"
+          queue: "test"
           os: "windows"
           arch: "${ARCH}"
         env:

--- a/pipelines/main/platforms/upload_freebsd.yml
+++ b/pipelines/main/platforms/upload_freebsd.yml
@@ -30,7 +30,7 @@ steps:
               limit: 3
         commands: "bash .buildkite/utilities/upload_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           os: "freebsd"
           arch: "${ARCH}"
         env:

--- a/pipelines/main/platforms/upload_linux.yml
+++ b/pipelines/main/platforms/upload_linux.yml
@@ -39,7 +39,7 @@ steps:
         soft_fail: ${ALLOW_FAIL?}
         commands: "bash .buildkite/utilities/upload_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
           sandbox_capable: "true"
           os: "linux"

--- a/pipelines/main/platforms/upload_macos.yml
+++ b/pipelines/main/platforms/upload_macos.yml
@@ -33,7 +33,7 @@ steps:
               limit: 3
         commands: "bash .buildkite/utilities/upload_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           os: "macos"
           arch: "${ARCH}"
         env:

--- a/pipelines/main/platforms/upload_windows.yml
+++ b/pipelines/main/platforms/upload_windows.yml
@@ -54,7 +54,7 @@ steps:
                 - "S3_BUCKET_PREFIX"
         timeout_in_minutes: ${TIMEOUT?}
         agents:
-          queue: "julia"
+          queue: "build"
           os: "windows"
         env:
           # Receive cryptic token from parent job

--- a/pipelines/scheduled/0_webui.yml
+++ b/pipelines/scheduled/0_webui.yml
@@ -6,7 +6,7 @@ steps:
     steps:
       - label: "Unlock secrets, launch pipelines"
         agents:
-          queue: "julia"
+          queue: "launch"
           cryptic_capable: "true"
           os: "linux"
         plugins:

--- a/pipelines/scheduled/coverage/coverage.yml
+++ b/pipelines/scheduled/coverage/coverage.yml
@@ -51,7 +51,7 @@ steps:
           echo "--- Process and upload coverage information"
           ./julia --color=yes .buildkite/pipelines/scheduled/coverage/upload_coverage.jl
         agents:
-          queue: "julia"
+          queue: "test"
           # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
           sandbox_capable: "true"
           os: "linux"
@@ -107,7 +107,7 @@ steps:
           echo "--- Process and upload coverage information"
           ./julia --color=yes .buildkite/pipelines/scheduled/coverage/upload_coverage.jl
         agents:
-          queue: "julia"
+          queue: "test"
           os: "macos"
           arch: "aarch64"
         env:
@@ -179,7 +179,7 @@ steps:
                 - "BUILDKITE_BUILD_NUMBER"
         timeout_in_minutes: 540 # 9h
         agents:
-          queue: "julia"
+          queue: "test"
           os: "windows"
           arch: "x86_64"
         env:
@@ -215,7 +215,7 @@ steps:
           echo "--- Signal completion of parallel coverage uploads"
           julia --color=yes .buildkite/pipelines/scheduled/coverage/finish_parallel_coverage.jl
         agents:
-          queue: "julia"
+          queue: "test"
           os: "linux"
           arch: "x86_64"
         env:

--- a/pipelines/scheduled/launch_signed_jobs.yml
+++ b/pipelines/scheduled/launch_signed_jobs.yml
@@ -39,7 +39,7 @@ steps:
                     - .buildkite/pipelines/scheduled/platforms/upload_windows.no_gpl.arches
         agents:
           cryptic_capable: "true"
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
         env:

--- a/pipelines/scheduled/launch_unsigned_jobs.yml
+++ b/pipelines/scheduled/launch_unsigned_jobs.yml
@@ -27,7 +27,7 @@ steps:
               .buildkite/pipelines/scheduled/platforms/build_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/build_linux.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "Source Tests (Allow Fail)"
@@ -44,7 +44,7 @@ steps:
               .buildkite/pipelines/scheduled/platforms/test_linux.schedule.arches \
               .buildkite/pipelines/main/platforms/test_linux.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
   - group: "no_GPL"
@@ -71,6 +71,6 @@ steps:
               .buildkite/pipelines/scheduled/platforms/build_windows.no_gpl.arches \
               .buildkite/pipelines/main/platforms/build_windows.yml
         agents:
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots

--- a/pipelines/scheduled/launch_upload_jobs.yml
+++ b/pipelines/scheduled/launch_upload_jobs.yml
@@ -27,7 +27,7 @@ steps:
           unset BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET
         agents:
           cryptic_capable: "true"
-          queue: "julia"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots
         env:

--- a/pipelines/scheduled/platforms/upload_linux.no_gpl.yml
+++ b/pipelines/scheduled/platforms/upload_linux.no_gpl.yml
@@ -43,7 +43,7 @@ steps:
         timeout_in_minutes: ${TIMEOUT?}
         commands: "bash .buildkite/utilities/upload_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
           sandbox_capable: "true"
           os: "linux"

--- a/pipelines/scheduled/platforms/upload_macos.no_gpl.yml
+++ b/pipelines/scheduled/platforms/upload_macos.no_gpl.yml
@@ -34,7 +34,7 @@ steps:
         timeout_in_minutes: ${TIMEOUT?}
         commands: "bash .buildkite/utilities/upload_julia.sh"
         agents:
-          queue: "julia"
+          queue: "build"
           os: "macos"
           arch: "${ARCH}"
         env:

--- a/pipelines/scheduled/platforms/upload_windows.no_gpl.yml
+++ b/pipelines/scheduled/platforms/upload_windows.no_gpl.yml
@@ -59,7 +59,7 @@ steps:
                 - "S3_BUCKET_PREFIX=bin-nogpl"
         timeout_in_minutes: ${TIMEOUT?}
         agents:
-          queue: "julia"
+          queue: "build"
           os: "windows"
         env:
           # Receive cryptic token from parent job


### PR DESCRIPTION
Backports the post-incident CI rework from `main` so the **1.10** release branch can upload pipelines again.

### Problem

Pipeline uploads on the release branches fail because the `Julia` Buildkite cluster no longer has a single `julia` queue:

```
ERROR  failed to upload and process pipeline: pipeline upload rejected: Queue 'julia' does not exist in the 'Julia' cluster
```

### Changes

- **Split the `julia` queue into `launch` / `build` / `test`** — backport of #543, #545, #546, #550. Queue assignments mirror `main` exactly:
  - `launch` — low-latency pipeline-upload (`launch_*`, web UI) jobs
  - `build` — compile + artifact upload jobs, plus ASAN/TSAN/llvmpasses
  - `test` — test + misc analysis jobs (incl. coverage)
- **Windows: make the post-checkout working-dir wipe robust under cygwin** + bump pinned `JuliaCI/julia` plugin `v1.13.5 → v1.13.8` — backport of #547.

The plugin version is plugin-versioned (not Julia-versioned) and matches what `main` now pins.

> Note: #548 (`test_julia`: skip `JuliaLowering_stdlibs` under rr) is **not** backported here — 1.10 has no JuliaLowering frontend, so there is no such test group to skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)