### PR TITLE
Fix shellcheck findings across ops and utilities scripts

### DIFF
--- a/ops/21_import_notary_key.sh
+++ b/ops/21_import_notary_key.sh
@@ -10,6 +10,7 @@
 # machine; securely delete the .p8 afterwards.
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source=SCRIPTDIR/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
 P8_FILE="${1:?usage: $0 AuthKey.p8 <issuer-id> <key-id>}"

--- a/ops/22_generate_macos_csr.sh
+++ b/ops/22_generate_macos_csr.sh
@@ -11,6 +11,7 @@
 # and AWS credentials with kms:GetPublicKey + kms:Sign on the key.
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source=SCRIPTDIR/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
 RCODESIGN="${RCODESIGN:-rcodesign}"

--- a/ops/23_put_tokens.sh
+++ b/ops/23_put_tokens.sh
@@ -13,6 +13,7 @@
 #   23_put_tokens.sh buildkite_analytics_token
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source=SCRIPTDIR/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
 NAME="${1:?usage: $0 <token-name>}"

--- a/ops/24_docs_deploy_pubkey.sh
+++ b/ops/24_docs_deploy_pubkey.sh
@@ -9,6 +9,7 @@
 # julia-oidc-docs-deploy role.
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source=SCRIPTDIR/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
 WORK="$(mktemp -d)"

--- a/ops/32_gen_test_codesign_cert.sh
+++ b/ops/32_gen_test_codesign_cert.sh
@@ -20,6 +20,7 @@
 # set), then commit the output. Requires the patched rcodesign and openssl.
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source=SCRIPTDIR/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
 RCODESIGN="${RCODESIGN:-rcodesign}"

--- a/ops/common.sh
+++ b/ops/common.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared configuration for the julia-buildkite AWS ops scripts.
 # Source this from the numbered scripts; do not run directly.
 #

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -28,6 +28,9 @@
 # (Sourced file: deliberately no `set -euo pipefail` here -- shell options
 # set in a sourced file leak into the calling script; strict mode belongs
 # to the entrypoints.)
+#
+# shellcheck disable=SC2317  # `return ... || exit ...`: if mistakenly executed instead of sourced, top-level `return` is an
+# error that bash continues past -- the `exit` keeps these guards fail-closed
 
 # AWS account that holds the Julia CI roles (not a secret).
 JULIA_CI_AWS_ACCOUNT_ID="${JULIA_CI_AWS_ACCOUNT_ID:-873569884612}"
@@ -132,7 +135,8 @@ buildkite-agent oidc request-token \
 
 export AWS_WEB_IDENTITY_TOKEN_FILE="${_OIDC_TOKEN_FILE}"
 export AWS_ROLE_ARN="arn:aws:iam::${JULIA_CI_AWS_ACCOUNT_ID}:role/julia-oidc-${_OIDC_ROLE_SUFFIX}"
-export AWS_ROLE_SESSION_NAME="bk-$(tr -dc 'a-zA-Z0-9=,.@-' <<<"${BUILDKITE_STEP_KEY:-job}" | cut -c1-48)-${BUILDKITE_BUILD_NUMBER:-0}"
+AWS_ROLE_SESSION_NAME="bk-$(tr -dc 'a-zA-Z0-9=,.@-' <<<"${BUILDKITE_STEP_KEY:-job}" | cut -c1-48)-${BUILDKITE_BUILD_NUMBER:-0}"
+export AWS_ROLE_SESSION_NAME
 export AWS_DEFAULT_REGION="${JULIA_CI_AWS_REGION}"
 export AWS_REGION="${JULIA_CI_AWS_REGION}"
 

--- a/utilities/macos/get_rcodesign.sh
+++ b/utilities/macos/get_rcodesign.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 RCODESIGN_VERSION="0.29.0+1"
 RCODESIGN_CRATE_VERSION="0.29.0"
+# shellcheck disable=SC2034  # read via ${!SHA_VAR} indirection below
 RCODESIGN_SHA256_x86_64_linux_gnu="9756d1cf93358e3bfcd12457450950d538c858325550cb8589f397beffbbaa06"
 RCODESIGN_BASE_URL="${RCODESIGN_BASE_URL:-https://github.com/JuliaBinaryWrappers/rcodesign_jll.jl/releases/download/rcodesign-v0.29.0%2B1}"
 

--- a/utilities/tests/oidc_smoke_test.sh
+++ b/utilities/tests/oidc_smoke_test.sh
@@ -71,9 +71,11 @@ echo "--- Negative: overwrite of an existing object"
 if OUT="$(put "${MY_BUCKET}" "${KEY}")"; then
     bad "overwrite unexpectedly succeeded"
 else
-    [[ "${OUT}" == *"PreconditionFailed"* || "${OUT}" == *"412"* || "${OUT}" == *"AccessDenied"* ]] \
-        && ok "overwrite refused" \
-        || bad "overwrite failed with unexpected error: ${OUT}"
+    if [[ "${OUT}" == *"PreconditionFailed"* || "${OUT}" == *"412"* || "${OUT}" == *"AccessDenied"* ]]; then
+        ok "overwrite refused"
+    else
+        bad "overwrite failed with unexpected error: ${OUT}"
+    fi
 fi
 
 echo "--- Negative: other pipeline's staging bucket"
@@ -100,12 +102,14 @@ fi
 
 echo "--- Bearer tokens"
 if [[ "${SLUG}" == "julia-pr" ]]; then
+    # shellcheck source=SCRIPTDIR/../aws_oidc.sh
     if (source .buildkite/utilities/aws_oidc.sh tokens) 2>/dev/null; then
         bad "tokens role obtainable on julia-pr"
     else
         ok "tokens refused on julia-pr (by aws_oidc.sh)"
     fi
 else
+    # shellcheck source=SCRIPTDIR/../aws_oidc.sh
     if (source .buildkite/utilities/aws_oidc.sh tokens \
             && aws sts get-caller-identity --query Arn --output text | grep -q tokens-ci); then
         ok "tokens-ci role assumable from julia-ci"
@@ -121,6 +125,7 @@ buildkite-agent oidc request-token \
     --lifetime 600 \
     --aws-session-tag "organization_id,pipeline_id,cluster_id,step_key" \
     > "${_PUB_TOKEN}"
+# shellcheck disable=SC2031  # the tokens checks re-source aws_oidc.sh in a subshell on purpose; this uses the top-level `stage` value
 PUBLISH_ROLE_ARN="${AWS_ROLE_ARN%/*}/julia-oidc-publish"
 if OUT="$(aws sts assume-role-with-web-identity \
         --role-arn "${PUBLISH_ROLE_ARN}" \

--- a/utilities/upload_to_s3.sh
+++ b/utilities/upload_to_s3.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared write-once S3 upload helper. Source this file, then call
 # `upload_to_s3 <local-file> <bucket/key>`; AWS credentials come from
 # Buildkite OIDC (source aws_oidc.sh first).


### PR DESCRIPTION
Real fixes:
- aws_oidc.sh: split declaration and export of AWS_ROLE_SESSION_NAME so the command substitution's exit status is not masked (SC2155).
- oidc_smoke_test.sh: rewrite an `A && B || C` chain as if/else so the failure branch cannot run after a successful check (SC2015).

Directives for intentional patterns:
- `# shellcheck shell=bash` in the sourced-only common.sh and upload_to_s3.sh, which have no shebang (SC2148).
- `# shellcheck source=...` for dynamically-prefixed source paths in the ops scripts and oidc_smoke_test.sh (SC1091).
- Disable SC2317 for the `return 1 2>/dev/null || exit 1` guards in aws_oidc.sh: the exit is a fail-closed fallback if the script is ever executed instead of sourced (bash continues past a top-level return).
- Disable SC2034 for the sha256 pin in get_rcodesign.sh, which is read via ${!SHA_VAR} indirection.
- Disable SC2031 in oidc_smoke_test.sh: the tokens checks re-source aws_oidc.sh in a subshell on purpose.