### PR TITLE
release-julia-1.13-new: build matrix + job-set specialization

### DIFF
--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -472,19 +472,15 @@ def main():
         allow_fail_group_text(),
     ]
 
-    # JuliaSyntax: gated on ./JuliaSyntax/Project.toml existing in the julia
-    # checkout (same conditional the old Check step used). Included verbatim
-    # as its own group (it is itself a launcher with its own notify).
-    juliasyntax_project = os.path.join(os.getcwd(), "JuliaSyntax", "Project.toml")
-    if os.path.exists(juliasyntax_project):
-        blocks.append(verbatim_group_text(os.path.join(MISC, "juliasyntax.launch.yml")))
-    else:
-        sys.stderr.write(
-            "./JuliaSyntax/Project.toml does NOT exist; omitting JuliaSyntax group\n"
-        )
-
-    # JuliaC: itself a launcher with its own group + notify -- include verbatim.
-    blocks.append(verbatim_group_text(os.path.join(MISC, "juliac", "test_juliac.yml")))
+    # NOTE (release-julia-1.13): the JuliaSyntax and JuliaC launch groups that
+    # `main` emits here are intentionally omitted on the release branch -- they
+    # are not part of release-1.13's CI job set (the pre-#544 launch flow never
+    # uploaded juliasyntax.launch.yml or juliac/test_juliac.yml). This port
+    # changes only the trust/routing architecture, not which jobs run; per-
+    # release job-set differences are expressed as branch content selected by
+    # julia's in-repo .buildkite-external-version pointer. To opt release-1.13
+    # into either group, re-add the corresponding `blocks.append(...)` from
+    # `main` (the juliasyntax.* / juliac/ YAMLs are already present in-tree).
 
     sys.stdout.write("steps:\n")
     sys.stdout.write("\n".join(blocks))


### PR DESCRIPTION
This is the sole release-1.13-specific commit layered on top of `master`. The release-julia-1.13 branch is now `master` + this commit, so the shared OIDC/KMS CI architecture (#544) stays byte-identical to master and future master -> release-* cherry-picks apply cleanly, per review feedback on #564.

Everything release-1.13-specific lives here:

  * Build/test matrix (pipelines/**/platforms/*.arches): pin the rootfs images to v6.00 / docker v7.10, put mmtk on the `package_linux` image, and drop master's Windows -Wno-error CFLAGS -- i.e. keep release-1.13's existing build environment rather than master's (1.14) one.

  * Job set (utilities/render_launch_pipeline.py): omit the JuliaSyntax and JuliaC launch groups, which are new on master and not part of release-1.13 CI. The juliasyntax.* / juliac/ YAMLs stay in-tree (from master), so either group re-enables by re-adding its `blocks.append(...)`.

NOT yet validated on Buildkite.