### PR TITLE
Add JuliaLowering compatibility smoke jobs

### DIFF
--- a/pipelines/main/launch_untrusted_builders.yml
+++ b/pipelines/main/launch_untrusted_builders.yml
@@ -13,8 +13,9 @@
 #
 # Now a SINGLE launch step runs `utilities/render_launch_pipeline.py`, which
 # renders ONE pre-grouped pipeline document (one `group:` per label:
-# Build / Check / Test / Allow Fail / JuliaSyntax / JuliaC, plus the
-# wait + julia-publish trigger), and uploads it with ONE `pipeline upload`.
+# Build / Check / Test / Allow Fail / JuliaSyntax / JuliaLowering / JuliaC,
+# plus the wait + julia-publish trigger), and uploads it with ONE
+# `pipeline upload`.
 #
 # The renderer reproduces the old behaviour EXACTLY:
 #   * The arches-templated platform YAMLs (platforms/{build,test}_*.yml) are
@@ -22,8 +23,8 @@
 #     old per-file `pipeline upload` performed (GROUP / ALLOW_FAIL / arches
 #     columns). Job grouping, keys, depends_on and soft_fail are preserved.
 #   * The static / launcher misc YAMLs (analyzegc, gcext, juliac, juliasyntax,
-#     ...) are emitted VERBATIM -- their double-dollar runtime escapes and their
-#     launch-env vars (e.g. gcext/test_revise, whose soft_fail is keyed off
+#     julialowering, ...) are emitted VERBATIM -- their double-dollar runtime
+#     escapes and launch-env vars (e.g. gcext/test_revise, whose soft_fail is keyed off
 #     ALLOW_FAIL) are left for THIS single `pipeline upload` to interpolate.
 #     That is why we still `export ALLOW_FAIL="false"` below.
 #   * PowerPC is omitted: launch_powerpc.jl only uploaded powerpc arches for

--- a/pipelines/main/misc/julialowering.yml
+++ b/pipelines/main/misc/julialowering.yml
@@ -1,0 +1,37 @@
+steps:
+  - group: "JuliaLowering"
+    notify:
+      - github_commit_status:
+          context: "JuliaLowering"
+    steps:
+      - label: "julialowering load/precompile linux/x86_64/{{matrix.julia_version}}"
+        timeout_in_minutes: 15
+        agents:
+          queue: "test"
+          os: "linux"
+          arch: "x86_64"
+        matrix:
+          setup:
+            julia_version:
+              - "1.12"
+              - "1.13"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              isolated_depot: true
+              persist_depot_dirs: packages,artifacts
+              update_registry: false
+              version: "{{matrix.julia_version}}"
+              arch: "x86_64"
+        commands: |
+          echo "--- Julia versioninfo"
+          julia -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
+
+          echo "--- Loading and precompiling JuliaLowering on Julia {{matrix.julia_version}}"
+          export JULIA_LOWERING_PRECOMPILE=true
+          julia --startup-file=no --project=@stdlib -e '
+              pushfirst!(LOAD_PATH, pwd())
+              using JuliaLowering
+          '

--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -18,7 +18,8 @@ It reproduces, exactly, what `launch_untrusted_builders.yml` used to upload:
     relevant.)
 
   * The static / nested misc YAMLs (misc/analyzegc.yml, misc/gcext.yml, the
-    juliac / juliasyntax launchers, ...) are emitted VERBATIM. We do NOT
+    juliac / juliasyntax launchers, the julialowering smoke job, ...) are
+    emitted VERBATIM. We do NOT
     pre-resolve their variables: they contain only `$$`-runtime escapes and/or
     launch-agent-env vars (e.g. `${ALLOW_FAIL?}` on gcext/test_revise). The
     final single `buildkite-agent pipeline upload` of this combined document
@@ -34,7 +35,7 @@ current master (1.14) it is a no-op, so the powerpc arches are intentionally
 omitted (see OMITTED_POWERPC below). This matches the runtime behaviour.
 
 The result is grouped into one `group:` per label: Build, Check, Test,
-Allow Fail, JuliaSyntax, JuliaC.
+Allow Fail, JuliaSyntax, JuliaLowering, JuliaC.
 """
 
 import os
@@ -239,7 +240,9 @@ def extract_inner_steps_text(text, where):
             group_indent = ind
             group_idx = i
             break
-    assert group_idx is not None, f"{where}: no group line found"
+    assert group_idx is not None and group_indent is not None, (
+        f"{where}: no group line found"
+    )
 
     # Find the group's own `steps:` key (the first `steps:` AFTER the group line
     # that is indented deeper than the group line).
@@ -251,7 +254,7 @@ def extract_inner_steps_text(text, where):
             continue
         if ind <= group_indent:
             break  # left the group without finding steps:
-        if re.match(rf'\s*steps:\s*$', line):
+        if re.match(r"\s*steps:\s*$", line):
             start = i + 1
             break
     assert start is not None, f"{where}: group has no steps: key"
@@ -481,6 +484,16 @@ def main():
     else:
         sys.stderr.write(
             "./JuliaSyntax/Project.toml does NOT exist; omitting JuliaSyntax group\n"
+        )
+
+    # JuliaLowering: run its Julia 1.12 load/precompile smoke test when present.
+    julialowering_project = os.path.join(os.getcwd(), "JuliaLowering", "Project.toml")
+    if os.path.exists(julialowering_project):
+        blocks.append(verbatim_group_text(os.path.join(MISC, "julialowering.yml")))
+    else:
+        sys.stderr.write(
+            "./JuliaLowering/Project.toml does NOT exist; "
+            "omitting JuliaLowering group\n"
         )
 
     # JuliaC: itself a launcher with its own group + notify -- include verbatim.


### PR DESCRIPTION
JuliaLang/julia#62367 restores enough compatibility for JETLS to load and precompile JuliaLowering on Julia 1.12, although currently there is no system to detect future regressions, as discussed in the PR.

So this commit adds Linux x86_64 matrix jobs for Julia 1.12 and 1.13 that load JuliaLowering with `JULIA_LOWERING_PRECOMPILE=true`, without persisting compiled caches, ensuring each job exercises precompilation. This also registers the new JuliaLowering group in the launch pipeline renderer.

Note that the full test suite executes lowered code and requires newer runtime support, so it cannot be used for this minimum compatibility coverage.