### PR TITLE
macOS notarize: break julia/julia-terminal hardlink before signing

### DIFF
--- a/utilities/macos/codesign.sh
+++ b/utilities/macos/codesign.sh
@@ -91,16 +91,6 @@ is_macho() {
     esac
 }
 
-# Inode number of $1, portable across GNU coreutils `stat -c`, BSD/macOS
-# `stat -f`, and a `ls -di` fallback. Used to sign each physical inode only
-# once: the bundle contains hardlinked Mach-Os (see the signing loop), and a
-# single filesystem holds the whole tree, so the inode alone identifies a file.
-inode_of() {
-    stat -c '%i' -- "${1}" 2>/dev/null \
-        || stat -f '%i' -- "${1}" 2>/dev/null \
-        || ls -di -- "${1}" 2>/dev/null | awk '{print $1}'
-}
-
 do_adhoc_codesign() {
     # Ad-hoc signing needs no key; use the system codesign as before.
     codesign --sign "-" \
@@ -210,8 +200,6 @@ elif [ -d "${TARGET}" ]; then
     STATUS_DIR="$(mktemp -d)"
     NUM_CODESIGNS=0
     NUM_SKIPPED=0
-    # Inodes already dispatched for signing, so each is signed at most once.
-    declare -A SIGNED_INODES=()
     while IFS= read -r -d '' exe_file; do
         # Skip files the KMS signer (rcodesign) can't sign -- they need no
         # signature, and the ad-hoc `codesign` handles them, so only filter on
@@ -227,21 +215,6 @@ elif [ -d "${TARGET}" ]; then
             NUM_SKIPPED="$((NUM_SKIPPED + 1))"
             continue
         fi
-        # Hardlink de-duplication. The bundle contains Mach-Os that are hardlinks
-        # to one inode -- notably julia's launcher, where the .app rule `ln`s
-        # Contents/Resources/julia/bin/julia-terminal to bin/julia. rcodesign
-        # signs a Mach-O IN PLACE, so handing two hardlinked paths to the
-        # parallel pool lets two signers mutate the SAME inode at once, tearing
-        # the signature -- Apple's notary then rejects every such path with "The
-        # signature of the binary is invalid." Sign each inode ONCE; the other
-        # hardlinks to it already carry that one valid signature.
-        exe_inode="$(inode_of "${exe_file}")"
-        if [[ -n "${exe_inode}" && -n "${SIGNED_INODES[${exe_inode}]:-}" ]]; then
-            echo "Skipping hardlink to already-signed inode ${exe_inode}: ${exe_file}"
-            NUM_SKIPPED="$((NUM_SKIPPED + 1))"
-            continue
-        fi
-        [[ -n "${exe_inode}" ]] && SIGNED_INODES["${exe_inode}"]=1
         # Block until a worker slot frees up before launching the next signer.
         while (( "$(jobs -rp | wc -l)" >= MAX_JOBS )); do wait -n 2>/dev/null || true; done
         { do_codesign "${exe_file}" || touch "${STATUS_DIR}/fail.${NUM_CODESIGNS}"; } &

--- a/utilities/upload_julia.sh
+++ b/utilities/upload_julia.sh
@@ -88,6 +88,26 @@ if [[ "${OS}" == "macos" || "${OS}" == "macosnogpl" ]]; then
     tar zxf "${UPLOAD_FILENAME}.app.tar.gz"
     chmod -R u+w "${APP_NAME}"
 
+    # Break the julia/julia-terminal hardlink before signing. contrib/mac/app
+    # builds the launcher as a hardlink: bin/julia-terminal and bin/julia are ONE
+    # inode with two names. The bundle's main executable is julia-terminal (via
+    # the Contents/MacOS/julia-terminal symlink), so the seal signs that inode
+    # with the MAIN-EXECUTABLE signature -- which lands on bin/julia too. Apple's
+    # notary then validates bin/julia as an ordinary nested binary, finds the
+    # main-executable signature, and rejects BOTH paths: "The signature of the
+    # binary is invalid." Split the inode into two independent regular files so
+    # each carries its own correct signature (nested for julia, main-executable
+    # for julia-terminal). A full copy keeps the name-based loader dispatch (see
+    # cli/loader_exe.c) and the bin/ rpath, exactly like the hardlink; bin/julia
+    # is the small loader, so the extra copy is negligible.
+    julia_bin="${APP_NAME}/Contents/Resources/julia/bin/julia"
+    julia_terminal="${APP_NAME}/Contents/Resources/julia/bin/julia-terminal"
+    if [[ -f "${julia_terminal}" && "${julia_terminal}" -ef "${julia_bin}" ]]; then
+        echo "--- [mac] Break julia/julia-terminal hardlink (independent signatures for notarization)"
+        rm -f "${julia_terminal}"
+        cp -p "${julia_bin}" "${julia_terminal}"
+    fi
+
     # Signing is split across three steps because the stdlib pkgimage checksum
     # fixup has to happen in the middle. Codesigning rewrites every pkgimage
     # Mach-O (.dylib), which changes its crc32c; the .ji caches embed that


### PR DESCRIPTION
Supersedes the inode-dedup in 205ae8f, which was the wrong layer: a julia-publish run (build #59) with that change still failed notarization with the identical error on both binaries --

  "The signature of the binary is invalid."
    Julia-1.14.app/Contents/Resources/julia/bin/julia
    Julia-1.14.app/Contents/Resources/julia/bin/julia-terminal

even though the dedup demonstrably ran ("Skipping hardlink to already-signed inode ..."). So the failure is not a concurrent-signing race.

Root cause is the shared inode itself. contrib/mac/app builds the launcher as a hardlink -- bin/julia-terminal and bin/julia are one inode with two names -- and the bundle's main executable is julia-terminal (via the Contents/MacOS/julia-terminal symlink). The bundle seal signs that inode with the MAIN-EXECUTABLE signature, which therefore also lands on bin/julia. Apple's notary validates bin/julia as an ordinary nested binary, finds a main-executable signature, and rejects both paths. (160 non-hardlinked Mach-Os in the same bundle notarize fine; only the hardlink pair fails.)

Fix: in upload_julia.sh, split the hardlink into two independent regular files before signing, so each gets its own correct signature. A full copy keeps the name-based loader dispatch (cli/loader_exe.c) and the bin/ rpath, exactly like the hardlink; bin/julia is the small loader so the extra copy is negligible. codesign.sh is reverted to its pre-205ae8f form.