### PR TITLE
Add julia-build-request: build a single commit on demand

### DIFF
--- a/ops/terraform/buildkite_ids.auto.tfvars
+++ b/ops/terraform/buildkite_ids.auto.tfvars
@@ -10,17 +10,24 @@
 buildkite_organization_id = "d409823c-5fa7-41c8-9033-7269c5fde4f3"
 
 buildkite_pipeline_ids = {
-  "julia-pr"           = "019ebd61-5b1f-428e-b08c-1b5a2111e001"
-  "julia-ci"           = "019ebd63-635e-4155-b60a-9d2815900786"
-  "julia-publish"      = "019ebd63-df36-4f53-a07f-4b31064df0f8"
-  "julia-buildkite-ci" = "019f3d33-d54f-4087-b70f-767d53b801d4"
+  "julia-pr"            = "019ebd61-5b1f-428e-b08c-1b5a2111e001"
+  "julia-ci"            = "019ebd63-635e-4155-b60a-9d2815900786"
+  "julia-publish"       = "019ebd63-df36-4f53-a07f-4b31064df0f8"
+  "julia-buildkite-ci"  = "019f3d33-d54f-4087-b70f-767d53b801d4"
+  "julia-build-request" = "019f9b49-354f-41ba-bfbf-a42d685724de"
 }
 
+# julia-build-request is pinned to the Julia (build) cluster like the other
+# untrusted build pipelines. Until the pipeline is actually moved there
+# (it was created in the JuliaCI cluster, which has no launch/build queues),
+# this fails closed: tokens minted from any other cluster don't match the
+# condition and the stage role cannot be assumed.
 buildkite_cluster_ids = {
-  "julia-pr"           = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
-  "julia-ci"           = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
-  "julia-buildkite-ci" = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
-  "julia-publish"      = "fd6c2af4-60c1-40ee-bdd5-88ecb6698fbc"
+  "julia-pr"            = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
+  "julia-ci"            = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
+  "julia-buildkite-ci"  = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
+  "julia-build-request" = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
+  "julia-publish"       = "fd6c2af4-60c1-40ee-bdd5-88ecb6698fbc"
 }
 
 # Isolated NON-PRODUCTION publish test stack (ops/terraform/test_publish.tf).

--- a/ops/terraform/iam.tf
+++ b/ops/terraform/iam.tf
@@ -61,6 +61,9 @@ locals {
     "julia-ci"           = "ci"
     # the julia-buildkite repository's own self-test CI
     "julia-buildkite-ci" = "buildkite"
+    # on-demand single-commit builds (REST API only, see
+    # pipelines/build_request/0_webui.yml)
+    "julia-build-request" = "request"
   }
 
   # The TRUSTED publish pipeline. julia-publish MUST be configured in

--- a/ops/terraform/iam.tf
+++ b/ops/terraform/iam.tf
@@ -100,6 +100,11 @@ locals {
       sub_patterns      = ["organization:${var.bk_org}:pipeline:julia-buildkite-ci:*"]
       step_key_patterns = null
     }
+    stage-request = {
+      pipelines         = ["julia-build-request"]
+      sub_patterns      = ["organization:${var.bk_org}:pipeline:julia-build-request:*"]
+      step_key_patterns = null
+    }
     # NB: there is deliberately no tokens-pr. A pull request executes
     # attacker-controlled code inside the job, which could exfiltrate any
     # bearer token the job can read -- so PR builds get NO tokens at all.

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -125,6 +125,9 @@ variable "staging_expiry_days" {
     "julia-ci"           = 30
     # self-test artifacts have no consumers; keep them briefly for humans
     "julia-buildkite-ci" = 14
+    # requested binaries are consumed by PkgEval right after staging; keep
+    # them a month so repeat evaluations of the same commit can reuse them
+    "julia-build-request" = 30
   }
 }
 

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -36,13 +36,13 @@ variable "buildkite_organization_id" {
 }
 
 variable "buildkite_pipeline_ids" {
-  description = "UUIDs of the four Buildkite pipelines, keyed by slug"
+  description = "UUIDs of the Buildkite pipelines, keyed by slug"
   type        = map(string)
   nullable    = false
 
   validation {
-    condition     = var.buildkite_pipeline_ids == null ? true : keys(var.buildkite_pipeline_ids) == tolist(["julia-buildkite-ci", "julia-ci", "julia-pr", "julia-publish"])
-    error_message = "buildkite_pipeline_ids must have exactly the keys julia-buildkite-ci, julia-ci, julia-pr, julia-publish."
+    condition     = var.buildkite_pipeline_ids == null ? true : keys(var.buildkite_pipeline_ids) == tolist(["julia-build-request", "julia-buildkite-ci", "julia-ci", "julia-pr", "julia-publish"])
+    error_message = "buildkite_pipeline_ids must have exactly the keys julia-build-request, julia-buildkite-ci, julia-ci, julia-pr, julia-publish."
   }
   validation {
     condition = var.buildkite_pipeline_ids == null ? true : alltrue([
@@ -106,6 +106,12 @@ variable "s3_staging_buckets" {
     # bucket separation means a self-test build can never place anything
     # juliaup or julia-publish would read.
     "julia-buildkite-ci" = "julialang-ephemeral-buildkite"
+    # On-demand builds of a single commit, requested through the REST API.
+    # A separate bucket for the same reason as the self-test one above: these
+    # builds can be for an arbitrary commit, so keeping them out of the
+    # julia-pr bucket means nothing juliaup reads can ever come from a
+    # requested build.
+    "julia-build-request" = "julialang-ephemeral-request"
   }
 }
 

--- a/pipelines/build_request/0_webui.yml
+++ b/pipelines/build_request/0_webui.yml
@@ -10,7 +10,10 @@
 #                  * Build pull requests: OFF
 #                  * builds are created only through the REST API, by a
 #                    machine user whose team access covers this pipeline
-#                    and nothing else
+#                    and nothing else. With branch webhook builds disabled,
+#                    the create-build POST must pass
+#                    "ignore_pipeline_branch_filters": true or the API
+#                    refuses it ("Branches have been disabled").
 #
 # Like julia-pr and julia-ci this pipeline is UNTRUSTED and holds no
 # secrets: it obtains credentials at runtime via Buildkite OIDC (see

--- a/pipelines/build_request/0_webui.yml
+++ b/pipelines/build_request/0_webui.yml
@@ -1,0 +1,45 @@
+# This file records the steps configured in the Buildkite webUI; modifying
+# this file has no effect -- paste it into the webUI when it changes.
+#
+# These steps belong to:
+#
+#   julia-build-request -- builds a single commit on demand, for consumers
+#                that need a binary for a commit CI did not build (or whose
+#                ephemeral artifact has expired). Settings:
+#                  * Trigger builds after pushing code: OFF
+#                  * Build pull requests: OFF
+#                  * builds are created only through the REST API, by a
+#                    machine user whose team access covers this pipeline
+#                    and nothing else
+#
+# Like julia-pr and julia-ci this pipeline is UNTRUSTED and holds no
+# secrets: it obtains credentials at runtime via Buildkite OIDC (see
+# utilities/aws_oidc.sh) and AWS IAM decides what the resulting identity
+# may do -- here, write-once uploads below its own attested commit in the
+# julia-build-request staging bucket, and nothing else.
+#
+# It may therefore be asked to build an arbitrary commit. That is
+# deliberate and safe for the same reason julia-pr is: the commit is
+# attested by Buildkite, the staging role can only write below that
+# commit's own path, and the bucket is separate from the one juliaup and
+# julia-publish read. A requested build can never masquerade as a CI
+# build of a different commit.
+#
+# The requester chooses the build variant with a build environment
+# variable:
+#
+#   PKGEVAL_BUILD_VARIANT=linux         (default)  x86_64-linux-gnu
+#   PKGEVAL_BUILD_VARIANT=linuxassert              x86_64-linux-gnuassert
+steps:
+  - group: "Launch"
+    steps:
+      - label: "Launch build"
+        agents:
+          queue: "launch"
+          os: "linux"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          buildkite-agent pipeline upload .buildkite/pipelines/build_request/launch.yml

--- a/pipelines/build_request/launch.yml
+++ b/pipelines/build_request/launch.yml
@@ -1,0 +1,30 @@
+# Render the one platform that was requested. Unlike the main pipeline we do
+# not iterate an `.arches` file: a build request is for a single commit and a
+# single variant, so the matching row is selected out of the linux arches file
+# and templated on its own.
+steps:
+  - label: ":hammer: render build request"
+    agents:
+      queue: "launch"
+      os: "linux"
+    plugins:
+      - JuliaCI/external-buildkite#v1:
+          version: "./.buildkite-external-version"
+          repo_url: "https://github.com/JuliaCI/julia-buildkite"
+    commands: |
+      # linux (default) or linuxassert; anything else is a caller error
+      VARIANT="${PKGEVAL_BUILD_VARIANT:-linux}"
+      case "$${VARIANT}" in
+          linux)       TRIPLET="x86_64-linux-gnu" ;;
+          linuxassert) TRIPLET="x86_64-linux-gnuassert" ;;
+          *) echo "ERROR: unknown PKGEVAL_BUILD_VARIANT '$${VARIANT}'" >&2; exit 1 ;;
+      esac
+      echo "--- Requested $${TRIPLET} at $${BUILDKITE_COMMIT}"
+
+      # Take just the requested row from the linux arches file, so the build
+      # step is templated exactly as the main pipeline would template it.
+      ARCHES=".buildkite/pipelines/main/platforms/build_linux.arches"
+      grep -E "^\s*#|^\s*$|\s$${TRIPLET}\s" "$${ARCHES}" > /tmp/build_request.arches
+      bash .buildkite/utilities/arches_pipeline_upload.sh \
+          /tmp/build_request.arches \
+          .buildkite/pipelines/main/platforms/build_linux.yml

--- a/pipelines/build_request/launch.yml
+++ b/pipelines/build_request/launch.yml
@@ -23,8 +23,12 @@ steps:
 
       # Take just the requested row from the linux arches file, so the build
       # step is templated exactly as the main pipeline would template it.
+      # GROUP and ALLOW_FAIL are the two template variables the arches row
+      # does not provide (same env-prefix convention as the scheduled launcher).
       ARCHES=".buildkite/pipelines/main/platforms/build_linux.arches"
       grep -E "^\s*#|^\s*$|\s$${TRIPLET}\s" "$${ARCHES}" > /tmp/build_request.arches
-      bash .buildkite/utilities/arches_pipeline_upload.sh \
+      GROUP="Build" \
+          ALLOW_FAIL="false" \
+          bash .buildkite/utilities/arches_pipeline_upload.sh \
           /tmp/build_request.arches \
           .buildkite/pipelines/main/platforms/build_linux.yml

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -68,6 +68,8 @@ case "${_OIDC_ROLE_SUFFIX}" in
     stage)
         if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
             _OIDC_ROLE_SUFFIX="stage-pr"
+        elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-build-request" ]]; then
+            _OIDC_ROLE_SUFFIX="stage-request"
         elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
             # The julia-buildkite repository's own self-test CI.
             _OIDC_ROLE_SUFFIX="stage-buildkite"

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -93,7 +93,7 @@ esac
 # IAM trust policies pin organization_id / pipeline_id / cluster_id so a
 # recreated or renamed pipeline with a matching slug cannot assume a role.
 case "${_OIDC_ROLE_SUFFIX}" in
-    stage-pr|stage-ci|stage-buildkite)
+    stage-pr|stage-ci|stage-buildkite|stage-request)
         # Trust: org/pipeline/cluster IDs. Permission policy: own commit path.
         _OIDC_AWS_SESSION_TAGS="organization_id,pipeline_id,cluster_id,build_commit"
         ;;

--- a/utilities/build_envs.sh
+++ b/utilities/build_envs.sh
@@ -272,6 +272,11 @@ export UPLOAD_FILENAME="julia-${TAR_VERSION?}-${OS?}-${ARCH?}"
 # bucket.
 if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
     STAGING_BUCKET="${STAGING_BUCKET:-julialang-ephemeral-pr}"
+elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-build-request" ]]; then
+    # On-demand builds of a single commit. Deliberately its own bucket: these
+    # may be for an arbitrary commit, so they must not land where juliaup
+    # (julia-pr) or julia-publish (julia-ci) read.
+    STAGING_BUCKET="${STAGING_BUCKET:-julialang-ephemeral-request}"
 elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
     # The julia-buildkite repository's own self-test CI stages to its own
     # bucket, which nothing (juliaup, julia-publish) ever consumes.


### PR DESCRIPTION
PkgEval needs a binary for whatever commit it is asked to evaluate. CI has usually already built it, and the staged artifact is fetched directly -- but not always: a closed PR, an expired ephemeral artifact, or a commit CI never built leave it with no option but to compile Julia itself, once per worker, which for a distributed run is hours of duplicated work.

Add an untrusted pipeline that builds exactly one commit and one variant, created only through the REST API (no push or PR triggers) by a machine user whose team access covers this pipeline alone.

It may be asked to build an arbitrary commit, which is safe for the same reasons julia-pr is: the commit is attested by Buildkite, the stage role can only write below its own attested commit, and -- as with the self-test CI -- it stages to its own bucket, so nothing juliaup or julia-publish reads can originate from a requested build.

Everything else follows the existing machinery: adding the slug to build_pipelines and s3_staging_buckets creates the bucket, its policies and the write-once stage role; build_envs.sh and aws_oidc.sh gain one branch each; the build step is the ordinary build_linux.yml template rendered for the single requested triplet.

Requires the pipeline UUID in buildkite_ids.auto.tfvars before apply.