### PR TITLE
Backport julia-build-request support (#577) to release-1.12

### DIFF
--- a/pipelines/build_request/0_webui.yml
+++ b/pipelines/build_request/0_webui.yml
@@ -1,0 +1,48 @@
+# This file records the steps configured in the Buildkite webUI; modifying
+# this file has no effect -- paste it into the webUI when it changes.
+#
+# These steps belong to:
+#
+#   julia-build-request -- builds a single commit on demand, for consumers
+#                that need a binary for a commit CI did not build (or whose
+#                ephemeral artifact has expired). Settings:
+#                  * Trigger builds after pushing code: OFF
+#                  * Build pull requests: OFF
+#                  * builds are created only through the REST API, by a
+#                    machine user whose team access covers this pipeline
+#                    and nothing else. With branch webhook builds disabled,
+#                    the create-build POST must pass
+#                    "ignore_pipeline_branch_filters": true or the API
+#                    refuses it ("Branches have been disabled").
+#
+# Like julia-pr and julia-ci this pipeline is UNTRUSTED and holds no
+# secrets: it obtains credentials at runtime via Buildkite OIDC (see
+# utilities/aws_oidc.sh) and AWS IAM decides what the resulting identity
+# may do -- here, write-once uploads below its own attested commit in the
+# julia-build-request staging bucket, and nothing else.
+#
+# It may therefore be asked to build an arbitrary commit. That is
+# deliberate and safe for the same reason julia-pr is: the commit is
+# attested by Buildkite, the staging role can only write below that
+# commit's own path, and the bucket is separate from the one juliaup and
+# julia-publish read. A requested build can never masquerade as a CI
+# build of a different commit.
+#
+# The requester chooses the build variant with a build environment
+# variable:
+#
+#   PKGEVAL_BUILD_VARIANT=linux         (default)  x86_64-linux-gnu
+#   PKGEVAL_BUILD_VARIANT=linuxassert              x86_64-linux-gnuassert
+steps:
+  - group: "Launch"
+    steps:
+      - label: "Launch build"
+        agents:
+          queue: "launch"
+          os: "linux"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          buildkite-agent pipeline upload .buildkite/pipelines/build_request/launch.yml

--- a/pipelines/build_request/launch.yml
+++ b/pipelines/build_request/launch.yml
@@ -1,0 +1,34 @@
+# Render the one platform that was requested. Unlike the main pipeline we do
+# not iterate an `.arches` file: a build request is for a single commit and a
+# single variant, so the matching row is selected out of the linux arches file
+# and templated on its own.
+steps:
+  - label: ":hammer: render build request"
+    agents:
+      queue: "launch"
+      os: "linux"
+    plugins:
+      - JuliaCI/external-buildkite#v1:
+          version: "./.buildkite-external-version"
+          repo_url: "https://github.com/JuliaCI/julia-buildkite"
+    commands: |
+      # linux (default) or linuxassert; anything else is a caller error
+      VARIANT="${PKGEVAL_BUILD_VARIANT:-linux}"
+      case "$${VARIANT}" in
+          linux)       TRIPLET="x86_64-linux-gnu" ;;
+          linuxassert) TRIPLET="x86_64-linux-gnuassert" ;;
+          *) echo "ERROR: unknown PKGEVAL_BUILD_VARIANT '$${VARIANT}'" >&2; exit 1 ;;
+      esac
+      echo "--- Requested $${TRIPLET} at $${BUILDKITE_COMMIT}"
+
+      # Take just the requested row from the linux arches file, so the build
+      # step is templated exactly as the main pipeline would template it.
+      # GROUP and ALLOW_FAIL are the two template variables the arches row
+      # does not provide (same env-prefix convention as the scheduled launcher).
+      ARCHES=".buildkite/pipelines/main/platforms/build_linux.arches"
+      grep -E "^\s*#|^\s*$|\s$${TRIPLET}\s" "$${ARCHES}" > /tmp/build_request.arches
+      GROUP="Build" \
+          ALLOW_FAIL="false" \
+          bash .buildkite/utilities/arches_pipeline_upload.sh \
+          /tmp/build_request.arches \
+          .buildkite/pipelines/main/platforms/build_linux.yml

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -65,6 +65,8 @@ case "${_OIDC_ROLE_SUFFIX}" in
     stage)
         if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
             _OIDC_ROLE_SUFFIX="stage-pr"
+        elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-build-request" ]]; then
+            _OIDC_ROLE_SUFFIX="stage-request"
         elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
             # The julia-buildkite repository's own self-test CI.
             _OIDC_ROLE_SUFFIX="stage-buildkite"
@@ -88,7 +90,7 @@ esac
 # IAM trust policies pin organization_id / pipeline_id / cluster_id so a
 # recreated or renamed pipeline with a matching slug cannot assume a role.
 case "${_OIDC_ROLE_SUFFIX}" in
-    stage-pr|stage-ci|stage-buildkite)
+    stage-pr|stage-ci|stage-buildkite|stage-request)
         # Trust: org/pipeline/cluster IDs. Permission policy: own commit path.
         _OIDC_AWS_SESSION_TAGS="organization_id,pipeline_id,cluster_id,build_commit"
         ;;

--- a/utilities/build_envs.sh
+++ b/utilities/build_envs.sh
@@ -272,6 +272,11 @@ export UPLOAD_FILENAME="julia-${TAR_VERSION?}-${OS?}-${ARCH?}"
 # bucket.
 if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
     STAGING_BUCKET="${STAGING_BUCKET:-julialang-ephemeral-pr}"
+elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "julia-build-request" ]]; then
+    # On-demand builds of a single commit. Deliberately its own bucket: these
+    # may be for an arbitrary commit, so they must not land where juliaup
+    # (julia-pr) or julia-publish (julia-ci) read.
+    STAGING_BUCKET="${STAGING_BUCKET:-julialang-ephemeral-request}"
 elif [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
     # The julia-buildkite repository's own self-test CI stages to its own
     # bucket, which nothing (juliaup, julia-publish) ever consumes.


### PR DESCRIPTION
Runtime files only (pipelines/build_request + the aws_oidc.sh and build_envs.sh branches): a julia-build-request build of a release-1.12 commit resolves .buildkite-external-version to this branch, so these must exist here for PkgEval to request release-branch builds. The terraform half of #577 stays on main -- the infrastructure is global and already applied.