### PR TITLE
juliac: repair stdlib pkgimage checksums after re-signing

### DIFF
--- a/pipelines/main/misc/juliac/test_juliac_macos.yml
+++ b/pipelines/main/misc/juliac/test_juliac_macos.yml
@@ -19,6 +19,11 @@ steps:
           # Re-sign after download
           .buildkite/utilities/macos/codesign.sh ./usr
 
+          # Re-signing changed the pkgimage bytes, so repair the checksums
+          # recorded in the stdlib .ji cache files (as test_julia.sh does);
+          # otherwise every stdlib cache is considered stale and recompiled.
+          JULIA_DEBUG=all ./usr/bin/julia .buildkite/utilities/update_stdlib_pkgimage_checksums.jl
+
           echo "--- Install and test JuliaC"
           unset JULIA_DEPOT_PATH
           if [ -f deps/jlutilities/juliac/Manifest.toml ]; then


### PR DESCRIPTION
The macOS JuliaC test jobs download the built julia tarball and re-sign every Mach-O so the tree executes on the test agent — but unlike `test_julia.sh`, they did not run `update_stdlib_pkgimage_checksums.jl` afterwards. Re-signing changes the pkgimage bytes and invalidates the checksums recorded in the stdlib `.ji` cache files, so every stdlib cache was considered stale and silently recompiled on the tester: the job never actually exercised the shipped bundled caches, and paid the recompile cost every run.

With JuliaLang/julia#62578 the mismatch stopped being silent (the precompilation driver briefly reported the corrupted caches as loadable, producing "failed to create a usable precompiled cache file" warnings — since fixed on the julia side), which is how the missing step was noticed.

This adds the same repair step the main macOS test pipeline runs (`test_julia.sh` codesign → checksum patch), using the tree's own julia in in-target mode.

Validated locally by reproducing the CI scenario: `codesign -s - --force` over a stdlib pkgimage makes `using` it emit the staleness warning and fall back; patching the recorded checksums the same way the script does restores a clean cache load.

This PR was written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)