### PR TITLE
ops: trust refs/heads/v* for the publish/docs-deploy roles

### DIFF
--- a/ops/terraform/iam.tf
+++ b/ops/terraform/iam.tf
@@ -75,6 +75,9 @@ locals {
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/heads/master:*",
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/heads/release-*:*",
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/tags/v*:*",
+    # The release tag flow: the julia-ci trigger step can only pass the tag
+    # name as `branch`, so the triggered publish build's ref is refs/heads/v*.
+    "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/heads/v*:*",
   ]
 
   # Per-role trust: which pipeline (by slug pattern in `sub` AND by


### PR DESCRIPTION
The julia-publish build for a release tag is created by the trigger step at the end of julia-ci, which can only pass the tag name as `branch`. The resulting build is a branch build (ref `refs/heads/v<version>`), so its OIDC sub matches none of the trusted patterns and every triplet fails at `sts:AssumeRoleWithWebIdentity`, as seen in the v1.13.0-rc2 publish run (https://buildkite.com/julialang/julia-publish/builds/144). The `refs/tags/v*` pattern anticipated a tag ref that a triggered build never has.

Add the `refs/heads/v*` pattern; the real trust boundary remains the pipeline UUID (plus PR builds being disabled on the publish pipeline slug) — these ref patterns are belt-and-braces, and the pipeline's branch limiting already includes `v*`.

Needs a `terraform apply` after merge; then the failed `publish all` / `upload docs` jobs of build 144 can simply be retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)