### PR TITLE
ops: add a julia-promote pipeline for the release bucket dance

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -43,6 +43,13 @@ only trust the publish pipeline's slug. There are three pipelines:
 - **`julia-ci`** — builds trusted refs only: master, release-*, tags, and the
   scheduled nightlies (untrusted to sign, but it is what triggers publish).
 - **`julia-publish`** — the trusted pipeline that signs + promotes.
+- **`julia-promote`** — the trusted pipeline that copies a published
+  release from the nightlies bucket into the release bucket
+  (julialang2, served at julialang-s3.julialang.org). No webhook or PR
+  builds; the release manager creates its builds manually (New Build
+  with branch = `v<version>`) after the julia-publish run for that tag
+  has finished. See `pipelines/promote/0_webui.yml` and
+  `utilities/promote_release.sh`.
 
 A fourth, untrusted pipeline, **`julia-buildkite-ci`**, is the
 julia-buildkite repository's own self-test CI (see `.buildkite/README.md`):
@@ -344,6 +351,19 @@ The single publish step signs and packages for every OS on linux:
   `utilities/upload_to_s3.sh` (412, then ETag comparison for identical
   content and the `build-commit` metadata stamp for a sibling build of
   the same commit), not by allowing overwrites.
+* Promoting a release to the release bucket: after the tag's
+  `julia-publish` run passes, create a New Build on `julia-promote` with
+  branch = `v<version>` (leave commit as HEAD; Buildkite resolves it to
+  the tag). The step re-maps the published objects into the release
+  bucket's historical layout, repoints the `julia-<majmin>-latest`
+  pointers, uploads the `bin/checksums/julia-<version>` files, and purges
+  the Fastly cache. It verifies (via the `build-commit` object metadata
+  stamped at publish time) that every promoted object was built from the
+  build's own commit, so a repointed tag cannot promote stale binaries.
+  Re-running is idempotent: version-named objects are write-once and
+  identical/same-commit re-uploads are accepted. Afterwards, dispatch the
+  CI workflow on JuliaLang/VersionsJSONUtil.jl to regenerate
+  versions.json.
 * Re-running a release: use **Rebuild** on the `julia-ci` tag build, or
   create a new `julia-ci` build with the branch set to the tag name
   (`v<version>`) — both enter the release tag flow. To re-run just the

--- a/ops/terraform/buildkite_ids.auto.tfvars
+++ b/ops/terraform/buildkite_ids.auto.tfvars
@@ -15,11 +15,7 @@ buildkite_pipeline_ids = {
   "julia-publish"       = "019ebd63-df36-4f53-a07f-4b31064df0f8"
   "julia-buildkite-ci"  = "019f3d33-d54f-4087-b70f-767d53b801d4"
   "julia-build-request" = "019f9b49-354f-41ba-bfbf-a42d685724de"
-  # FIXME: create the julia-promote pipeline in the Secure cluster (see
-  # pipelines/promote/0_webui.yml for the required settings), then paste
-  # its UUID here before applying. The zero UUID fails validation, so an
-  # apply without the real pipeline is impossible.
-  "julia-promote" = "00000000-0000-0000-0000-000000000000"
+  "julia-promote"       = "019ff0fe-06b0-4394-a064-b74b242fc7a5"
 }
 
 # julia-build-request is pinned to the Julia (build) cluster like the other

--- a/ops/terraform/buildkite_ids.auto.tfvars
+++ b/ops/terraform/buildkite_ids.auto.tfvars
@@ -15,6 +15,11 @@ buildkite_pipeline_ids = {
   "julia-publish"       = "019ebd63-df36-4f53-a07f-4b31064df0f8"
   "julia-buildkite-ci"  = "019f3d33-d54f-4087-b70f-767d53b801d4"
   "julia-build-request" = "019f9b49-354f-41ba-bfbf-a42d685724de"
+  # FIXME: create the julia-promote pipeline in the Secure cluster (see
+  # pipelines/promote/0_webui.yml for the required settings), then paste
+  # its UUID here before applying. The zero UUID fails validation, so an
+  # apply without the real pipeline is impossible.
+  "julia-promote" = "00000000-0000-0000-0000-000000000000"
 }
 
 # julia-build-request is pinned to the Julia (build) cluster like the other
@@ -28,6 +33,8 @@ buildkite_cluster_ids = {
   "julia-buildkite-ci"  = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
   "julia-build-request" = "ae7e6bd1-fde8-433d-bac7-9d2d01108ed6"
   "julia-publish"       = "fd6c2af4-60c1-40ee-bdd5-88ecb6698fbc"
+  # The Secure cluster, same as julia-publish.
+  "julia-promote" = "fd6c2af4-60c1-40ee-bdd5-88ecb6698fbc"
 }
 
 # Isolated NON-PRODUCTION publish test stack (ops/terraform/test_publish.tf).

--- a/ops/terraform/iam.tf
+++ b/ops/terraform/iam.tf
@@ -33,6 +33,12 @@
 #                     can never produce a build under that slug, the slug
 #                     is the trust boundary -- not the (PR-spoofable)
 #                     branch name.
+#   julia-oidc-promote  TRUSTED. Read the nightlies bucket, write the
+#                     release bucket (julialang2). Assumable ONLY from the
+#                     `julia-promote` pipeline slug, whose builds are
+#                     created manually by the release manager (no webhook
+#                     or PR builds; see pipelines/promote/0_webui.yml).
+#                     No KMS.
 #   julia-oidc-docs-deploy  TRUSTED. kms:Sign with the docs SSH key; publish
 #                     pipeline only.
 #
@@ -43,8 +49,9 @@
 #
 # Overwrite protection: every PutObject must use the S3 conditional write
 # header (s3:if-none-match = "*"), i.e. uploads fail if the object already
-# exists. The only exception is `julia-latest-*` pointer objects, which the
-# publish pipeline intentionally repoints.
+# exists. The only exceptions are the `julia-latest-*` (publish) and
+# `julia-<majmin>-latest-*` (promote) pointer objects, which are
+# intentionally repointed.
 
 data "aws_caller_identity" "current" {}
 
@@ -75,6 +82,16 @@ locals {
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/heads/master:*",
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/heads/release-*:*",
     "organization:${var.bk_org}:pipeline:julia-publish:ref:refs/tags/v*:*",
+  ]
+
+  # The TRUSTED promote pipeline (release-manager-triggered bucket dance,
+  # see utilities/promote_release.sh). Builds are created manually with the
+  # release tag name as the branch, so the ref is refs/heads/v<version>.
+  # Same posture as julia-publish: manual/no-PR builds only, slug+UUID is
+  # the boundary, ref patterns are belt-and-braces.
+  promote_sub_patterns = [
+    "organization:${var.bk_org}:pipeline:julia-promote:ref:refs/heads/v*:*",
+    "organization:${var.bk_org}:pipeline:julia-promote:ref:refs/tags/v*:*",
   ]
 
   # Per-role trust: which pipeline (by slug pattern in `sub` AND by
@@ -118,6 +135,11 @@ locals {
       sub_patterns      = local.publish_sub_patterns
       step_key_patterns = ["publish_*"]
     }
+    promote = {
+      pipelines         = ["julia-promote"]
+      sub_patterns      = local.promote_sub_patterns
+      step_key_patterns = ["promote_*"]
+    }
     docs-deploy = {
       pipelines         = ["julia-publish"]
       sub_patterns      = local.publish_sub_patterns
@@ -146,6 +168,10 @@ locals {
     "arn:aws:s3:::${var.s3_bucket}/${var.s3_bucket_prefix}",
     "arn:aws:s3:::${var.s3_nogpl_bucket}/${var.s3_nogpl_prefix}",
   ]
+
+  # The release bucket the promote pipeline copies published binaries into
+  # (served at julialang-s3.julialang.org).
+  release_path = "arn:aws:s3:::${var.s3_release_bucket}/bin"
 }
 
 data "aws_iam_policy_document" "trust" {
@@ -336,6 +362,69 @@ resource "aws_iam_role_policy" "publish" {
   name   = "sign-and-promote-staged-artifacts-to-release"
   role   = aws_iam_role.publish.id
   policy = data.aws_iam_policy_document.publish.json
+}
+
+# ---- julia-oidc-promote (TRUSTED) -------------------------------------------
+# Copy a published release from the nightlies bucket into the release
+# bucket's layout (the "bucket dance"; utilities/promote_release.sh).
+# Assumable only from the julia-promote pipeline slug, whose builds are
+# created manually by the release manager. No KMS: the artifacts were
+# already signed by publish, this role only re-maps them.
+
+resource "aws_iam_role" "promote" {
+  name                 = "julia-oidc-promote"
+  description          = "Buildkite promote: copy published release binaries to the release bucket (via OIDC)"
+  assume_role_policy   = data.aws_iam_policy_document.trust["promote"].json
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "promote" {
+  statement {
+    sid       = "ReadPublishedArtifacts"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.s3_bucket}/${var.s3_bucket_prefix}/*"]
+  }
+
+  statement {
+    sid       = "WriteOnceToReleaseBucket"
+    actions   = ["s3:PutObject"]
+    resources = ["${local.release_path}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:if-none-match"
+      values   = ["*"]
+    }
+  }
+
+  # The release bucket is ACL-based (objects are uploaded public-read);
+  # see SetPublicReadAclOnFinalObjects on the publish role for why this
+  # cannot be folded into the conditioned statement above.
+  statement {
+    sid       = "SetPublicReadAclOnReleaseObjects"
+    actions   = ["s3:PutObjectAcl"]
+    resources = ["${local.release_path}/*"]
+  }
+
+  # julia-<majmin>-latest pointers live at bin/<os>/<arch>/<majmin>/ and
+  # are intentionally repointed on every promotion of that series.
+  statement {
+    sid       = "RepointMajminLatestPointers"
+    actions   = ["s3:PutObject", "s3:PutObjectAcl"]
+    resources = ["${local.release_path}/*/*/*/julia-*-latest-*"]
+  }
+
+  statement {
+    sid       = "ReadReleaseForRetryChecks"
+    actions   = ["s3:GetObject"]
+    resources = ["${local.release_path}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "promote" {
+  name   = "copy-published-release-to-release-bucket"
+  role   = aws_iam_role.promote.id
+  policy = data.aws_iam_policy_document.promote.json
 }
 
 # ---- julia-oidc-docs-deploy (TRUSTED) ---------------------------------------

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -41,8 +41,8 @@ variable "buildkite_pipeline_ids" {
   nullable    = false
 
   validation {
-    condition     = var.buildkite_pipeline_ids == null ? true : keys(var.buildkite_pipeline_ids) == tolist(["julia-build-request", "julia-buildkite-ci", "julia-ci", "julia-pr", "julia-publish"])
-    error_message = "buildkite_pipeline_ids must have exactly the keys julia-build-request, julia-buildkite-ci, julia-ci, julia-pr, julia-publish."
+    condition     = var.buildkite_pipeline_ids == null ? true : keys(var.buildkite_pipeline_ids) == tolist(["julia-build-request", "julia-buildkite-ci", "julia-ci", "julia-pr", "julia-promote", "julia-publish"])
+    error_message = "buildkite_pipeline_ids must have exactly the keys julia-build-request, julia-buildkite-ci, julia-ci, julia-pr, julia-promote, julia-publish."
   }
   validation {
     condition = var.buildkite_pipeline_ids == null ? true : alltrue([
@@ -80,6 +80,12 @@ variable "s3_nogpl_bucket" {
   description = "S3 bucket for the scheduled no-GPL builds"
   type        = string
   default     = "julialang-nogpl"
+}
+
+variable "s3_release_bucket" {
+  description = "Release bucket the promote pipeline copies published binaries into (served at julialang-s3.julialang.org)"
+  type        = string
+  default     = "julialang2"
 }
 
 variable "s3_nogpl_prefix" {

--- a/pipelines/promote/0_webui.yml
+++ b/pipelines/promote/0_webui.yml
@@ -1,0 +1,37 @@
+# This file records the steps configured in the julia-promote pipeline's
+# webUI; modifying this file has no effect -- paste it into the webUI when
+# it changes.
+#
+# julia-promote copies a published release from the nightlies bucket to
+# the release bucket (the "bucket dance", see utilities/promote_release.sh).
+# Builds are created MANUALLY by the release manager: New Build with
+# branch = v<version> (and commit left as HEAD, which resolves to the
+# tag), after the julia-publish run for that tag has completed.
+#
+# SECURITY: like julia-publish, the pipeline slug is what the
+# julia-oidc-promote IAM role trusts. It MUST be configured in Buildkite
+# with:
+#   * Trigger builds after pushing code: OFF
+#   * Build pull requests: OFF (including from third-party forked
+#     repositories)
+#   * Branch limiting: v*
+#   * Same cluster as julia-publish (the cluster_id trust condition)
+#
+# Unlike julia-publish, the steps are loaded from julia-buildkite `main`
+# rather than the julia checkout's pinned .buildkite-external-version: a
+# promotion may target an older tag whose pin predates this pipeline, and
+# promote runs no code from the julia tree at all -- the julia checkout
+# contributes nothing but the (Buildkite-attested) commit and branch name.
+steps:
+  - group: "Promote"
+    steps:
+      - label: "Launch promote"
+        agents:
+          queue: "default"
+          os: "linux"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "main"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+        commands: |
+          buildkite-agent pipeline upload .buildkite/pipelines/promote/launch.yml

--- a/pipelines/promote/launch.yml
+++ b/pipelines/promote/launch.yml
@@ -1,0 +1,39 @@
+# Launched by the julia-promote pipeline (see 0_webui.yml). A single
+# trusted step copies the published release binaries from the nightlies
+# bucket into the release bucket's layout, updates the checksum files and
+# latest pointers, and purges the CDN. No signing happens here -- the
+# artifacts were signed by julia-publish; this step only re-maps them.
+steps:
+  - group: "Promote"
+    steps:
+      - label: ":package: promote release"
+        key: "promote_all"
+        # One promotion at a time: concurrent runs would race on the
+        # julia-<majmin>-latest pointer repoints.
+        concurrency: 1
+        concurrency_group: 'promote/julialang2'
+        concurrency_method: eager
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              # Track main, not the julia checkout's pin -- see 0_webui.yml.
+              version: "main"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              # Runs on the bare agent, only so the sandbox plugin below has
+              # a host julia to launch Sandbox.jl with.
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.10' # GREP_ME: Keep this updated to LTS. Do not set it to '1' or 'stable' or 'latest'.
+          - JuliaCI/sandbox#v2:
+              # The julia_publish rootfs carries the aws CLI (and curl),
+              # which the bare agents lack. x86_64-only image.
+              rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v8.6/julia_publish.x86_64.tar.gz
+              rootfs_treehash: "8b28c5b8937f25827c1ad4b6a3bc1bb90c9e9087"
+              uid: 1000
+              gid: 1000
+        timeout_in_minutes: 60
+        commands: "bash .buildkite/utilities/promote_release.sh"
+        agents:
+          queue: "default"
+          sandbox_capable: "true"
+          os: "linux"
+          arch: "x86_64"

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -8,6 +8,7 @@
 #
 #     source .buildkite/utilities/aws_oidc.sh stage       # untrusted: write-once to own pipeline's staging bucket, <sha>/ path
 #     source .buildkite/utilities/aws_oidc.sh publish     # trusted: sign + promote to final (publish pipeline only)
+#     source .buildkite/utilities/aws_oidc.sh promote     # trusted: copy published release to the release bucket (promote pipeline only)
 #     source .buildkite/utilities/aws_oidc.sh docs-deploy # trusted: docs deploy SSH signing via KMS
 #     source .buildkite/utilities/aws_oidc.sh tokens      # CI telemetry tokens from SSM (julia-ci only)
 #
@@ -55,7 +56,13 @@ case "${_OIDC_ROLE_SUFFIX}" in
             return 1 2>/dev/null || exit 1
         fi
         ;;&
-    publish|docs-deploy)
+    promote)
+        if [[ "${BUILDKITE_PIPELINE_SLUG:-}" != *promote* ]]; then
+            echo "ERROR: promote role requested from non-promote pipeline '${BUILDKITE_PIPELINE_SLUG:-}'" >&2
+            return 1 2>/dev/null || exit 1
+        fi
+        ;;&
+    publish|docs-deploy|promote)
         if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
             echo "ERROR: ${_OIDC_ROLE_SUFFIX} role must not be requested on a pull request build" >&2
             return 1 2>/dev/null || exit 1
@@ -97,7 +104,7 @@ case "${_OIDC_ROLE_SUFFIX}" in
         # Trust: org/pipeline/cluster IDs. Permission policy: own commit path.
         _OIDC_AWS_SESSION_TAGS="organization_id,pipeline_id,cluster_id,build_commit"
         ;;
-    publish|docs-deploy)
+    publish|docs-deploy|promote)
         # Trust: org/pipeline/cluster IDs and step key. KMS policies also gate
         # the trusted roles by step_key.
         _OIDC_AWS_SESSION_TAGS="organization_id,pipeline_id,cluster_id,step_key"

--- a/utilities/promote_release.sh
+++ b/utilities/promote_release.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Promote a published Julia release from the nightlies bucket to the
+# release bucket (the "bucket dance"): julialangnightlies -> julialang2,
+# served at https://julialang-s3.julialang.org, which is where
+# versions.json, juliaup, setup-julia and the website point.
+#
+# Runs as the single trusted step of the julia-promote pipeline. Builds
+# are created MANUALLY (New Build with branch = v<version>) after the
+# julia-publish run for that tag has completed; the version identity is
+# taken from the branch, never from checkout state, mirroring the publish
+# flow's naming (see TAR_VERSION in build_envs.sh).
+#
+# The release bucket keeps the historical buildbot-era layout (folder
+# x86_64->x64, i686->x86; short mac64/win64 file names), which is what
+# VersionsJSONUtil.jl constructs URLs against. This script re-maps the
+# published objects into that layout, repoints the julia-<majmin>-latest
+# pointers, generates the bin/checksums/julia-<version> files, purges the
+# Fastly cache, and verifies everything is reachable via the CDN.
+set -euo pipefail
+
+if [[ ! "${BUILDKITE_BRANCH:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+    echo "ERROR: BUILDKITE_BRANCH='${BUILDKITE_BRANCH:-}' is not a release tag; create this build with branch = v<version>" >&2
+    exit 1
+fi
+VERSION="${BUILDKITE_BRANCH#v}"
+MAJMIN="$(cut -d. -f1-2 <<<"${VERSION}")"
+
+# Defense in depth, as in publish.sh: refuse unless this commit is a
+# genuine release commit on the canonical upstream. (Buildkite resolves
+# branch = v<version> to the tag's commit, so BUILDKITE_COMMIT is the
+# release commit.)
+bash .buildkite/utilities/verify_trusted_commit.sh
+
+# shellcheck source=SCRIPTDIR/aws_oidc.sh
+source .buildkite/utilities/aws_oidc.sh promote
+# shellcheck source=SCRIPTDIR/upload_to_s3.sh
+source .buildkite/utilities/upload_to_s3.sh
+
+# The non-production test stack may override these.
+SRC_BUCKET="${SRC_BUCKET:-julialangnightlies}"
+DEST_BUCKET="${DEST_BUCKET:-julialang2}"
+CDN_URL="${CDN_URL:-https://julialang-s3.julialang.org}"
+
+# "<file basename> <source dir> <destination dir>", dirs relative to bin/.
+# Sources are what upload_julia.sh published for a v* tag; destinations
+# are the release-bucket layout (verified against v1.13.0-rc1).
+MAPPINGS=(
+    "julia-${VERSION}-linux-x86_64.tar.gz    linux/x86_64/${MAJMIN}   linux/x64/${MAJMIN}"
+    "julia-${VERSION}-linux-i686.tar.gz      linux/i686/${MAJMIN}     linux/x86/${MAJMIN}"
+    "julia-${VERSION}-linux-aarch64.tar.gz   linux/aarch64/${MAJMIN}  linux/aarch64/${MAJMIN}"
+    "julia-${VERSION}-mac64.tar.gz           mac/x64/${MAJMIN}        mac/x64/${MAJMIN}"
+    "julia-${VERSION}-mac64.dmg              mac/x64/${MAJMIN}        mac/x64/${MAJMIN}"
+    "julia-${VERSION}-macaarch64.tar.gz      mac/aarch64/${MAJMIN}    mac/aarch64/${MAJMIN}"
+    "julia-${VERSION}-macaarch64.dmg         mac/aarch64/${MAJMIN}    mac/aarch64/${MAJMIN}"
+    "julia-${VERSION}-win64.exe              winnt/x64/${MAJMIN}      winnt/x64/${MAJMIN}"
+    "julia-${VERSION}-win64.zip              winnt/x64/${MAJMIN}      winnt/x64/${MAJMIN}"
+    "julia-${VERSION}-win64.tar.gz           winnt/x64/${MAJMIN}      winnt/x64/${MAJMIN}"
+    "julia-${VERSION}-win32.exe              winnt/x86/${MAJMIN}      winnt/x86/${MAJMIN}"
+    "julia-${VERSION}-win32.zip              winnt/x86/${MAJMIN}      winnt/x86/${MAJMIN}"
+    "julia-${VERSION}-win32.tar.gz           winnt/x86/${MAJMIN}      winnt/x86/${MAJMIN}"
+    "julia-${VERSION}-freebsd-x86_64.tar.gz  freebsd/x86_64/${MAJMIN} freebsd/x64/${MAJMIN}"
+)
+
+# Every .tar.gz has a KMS-GPG detached signature alongside it.
+with_asc() {
+    echo "$1"
+    [[ "$1" == *.tar.gz ]] && echo "$1.asc"
+    return 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+cd "${WORK}"
+
+echo "--- Download published ${VERSION} artifacts from s3://${SRC_BUCKET}"
+for m in "${MAPPINGS[@]}"; do
+    read -r base srcdir _ <<<"${m}"
+    for f in $(with_asc "${base}"); do
+        # Provenance: the publish role stamped every object with the
+        # commit of the build that produced it. Refuse to promote an
+        # object from a different commit under this version's name (e.g.
+        # a repointed tag whose artifacts were never re-published).
+        remote_commit="$(aws s3api head-object --bucket "${SRC_BUCKET}" --key "bin/${srcdir}/${f}" \
+            --query 'Metadata."build-commit"' --output text)"
+        if [[ "${remote_commit}" != "${BUILDKITE_COMMIT}" ]]; then
+            echo "ERROR: s3://${SRC_BUCKET}/bin/${srcdir}/${f} was built from commit '${remote_commit}', not ${BUILDKITE_COMMIT}" >&2
+            exit 1
+        fi
+        aws s3 cp --only-show-errors "s3://${SRC_BUCKET}/bin/${srcdir}/${f}" "${f}"
+    done
+done
+
+echo "--- Generate checksum files"
+# Binaries only (no .asc), sorted by name -- the historical format of
+# bin/checksums/julia-<version>.{sha256,md5}.
+BINARIES="$(printf '%s\n' "${MAPPINGS[@]}" | awk '{print $1}' | sort)"
+# shellcheck disable=SC2086
+sha256sum ${BINARIES} > "julia-${VERSION}.sha256"
+# shellcheck disable=SC2086
+md5sum ${BINARIES} > "julia-${VERSION}.md5"
+cat "julia-${VERSION}.sha256"
+
+echo "--- Promote to s3://${DEST_BUCKET}"
+PURGE_KEYS=()
+for m in "${MAPPINGS[@]}"; do
+    read -r base _ destdir <<<"${m}"
+    latest="julia-${MAJMIN}-latest-${base#julia-"${VERSION}"-}"
+    for f in $(with_asc "${base}"); do
+        upload_to_s3 "${f}" "${DEST_BUCKET}/bin/${destdir}/${f}"
+        PURGE_KEYS+=( "bin/${destdir}/${f}" )
+        # Repoint the majmin-latest copy (upload_to_s3 overwrites
+        # julia-*-latest-* names; write-once applies to everything else).
+        latest_name="${latest}${f#"${base}"}"
+        upload_to_s3 "${f}" "${DEST_BUCKET}/bin/${destdir}/${latest_name}"
+        PURGE_KEYS+=( "bin/${destdir}/${latest_name}" )
+    done
+done
+for ext in sha256 md5; do
+    upload_to_s3 "julia-${VERSION}.${ext}" "${DEST_BUCKET}/bin/checksums/julia-${VERSION}.${ext}"
+    PURGE_KEYS+=( "bin/checksums/julia-${VERSION}.${ext}" )
+done
+
+echo "--- Purge the Fastly cache"
+for key in "${PURGE_KEYS[@]}"; do
+    curl -fsS -o /dev/null -X PURGE "${CDN_URL}/${key}" \
+        || echo "WARN: cache purge failed for ${CDN_URL}/${key}" >&2
+done
+
+echo "--- Verify everything is reachable via ${CDN_URL}"
+FAILED=()
+for key in "${PURGE_KEYS[@]}"; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' -I "${CDN_URL}/${key}")"
+    [[ "${code}" == "200" ]] || FAILED+=( "${code} ${CDN_URL}/${key}" )
+done
+if [[ "${#FAILED[@]}" -gt 0 ]]; then
+    printf '%s\n' "${FAILED[@]}" >&2
+    echo "ERROR: ${#FAILED[@]} object(s) not reachable via the CDN" >&2
+    exit 1
+fi
+
+echo "+++ Promoted ${VERSION}: ${#PURGE_KEYS[@]} objects live on ${CDN_URL}"
+echo "Next: dispatch the CI workflow on JuliaLang/VersionsJSONUtil.jl to regenerate versions.json."

--- a/utilities/upload_to_s3.sh
+++ b/utilities/upload_to_s3.sh
@@ -21,9 +21,9 @@ export AWS_EC2_METADATA_DISABLED=true
 # object (S3 conditional write, If-None-Match: *). If the object already
 # exists we accept it iff its content matches what we have locally (a
 # retried job re-uploading the same bytes), OR iff it was uploaded by
-# another build of the same commit (see below). `julia-latest-*` pointer
-# objects are intentionally overwritten (and only the publish role is
-# allowed to do so).
+# another build of the same commit (see below). `julia-latest-*` and
+# `julia-<majmin>-latest-*` pointer objects are intentionally overwritten
+# (and only the publish resp. promote roles are allowed to do so).
 upload_to_s3() {
     local file="$1" target="$2"
     local bucket="${target%%/*}"
@@ -49,7 +49,7 @@ upload_to_s3() {
     # against a bucket whose role permits an unconditional PutObject -- the
     # production roles' IAM denies it (write-once), so the flag is inert on the
     # real publish path even if accidentally set.
-    if [[ "${UPLOAD_TO_S3_OVERWRITE:-0}" == "1" || "$(basename "${key}")" == julia-latest-* ]]; then
+    if [[ "${UPLOAD_TO_S3_OVERWRITE:-0}" == "1" || "$(basename "${key}")" == julia-latest-* || "$(basename "${key}")" == julia-*-latest-* ]]; then
         aws s3api put-object \
             --bucket "${bucket}" --key "${key}" \
             --body "${file}" ${acl_args[@]+"${acl_args[@]}"} \


### PR DESCRIPTION
Promoting a release from the nightlies bucket to the release bucket (julialang2, served at julialang-s3.julialang.org) has been a manual, undocumented release-manager step with ad-hoc AWS credentials. This adds a trusted **julia-promote** pipeline that does it as a single step: the release manager creates a New Build with the tag name as branch (after the tag's julia-publish run has passed), and the step:

- re-maps the published artifacts into the release bucket's historical layout (`linux/x86_64`→`linux/x64`, `i686`→`x86`, `freebsd/x86_64`→`freebsd/x64`; the mac/winnt short names map 1:1) — verified against what v1.13.0-rc1 looks like on julialang2
- repoints the `julia-<majmin>-latest` pointers
- generates and uploads `bin/checksums/julia-<version>.{sha256,md5}`
- purges the Fastly cache and verifies every object is reachable via the CDN

Trust posture mirrors julia-publish: manual/no-PR builds only, a dedicated `julia-oidc-promote` role gated on the pipeline UUID + `promote_*` step keys, write-once uploads (the majmin-latest pointers become the second overwrite exception in `upload_to_s3.sh`), and a provenance check that each promoted object's `build-commit` metadata (stamped by the publish role) matches the build's own commit — so a repointed tag cannot silently promote stale binaries. No KMS access; everything was already signed by publish.

One deliberate divergence: the pipeline loads its steps from julia-buildkite `main` instead of the julia checkout's `.buildkite-external-version` pin, because a promotion may target an older tag whose pin predates this pipeline, and the step runs no code from the julia tree (the checkout contributes only the attested commit + branch name).

**Deployment checklist** (admin with Buildkite + AWS access):
1. Create the `julia-promote` pipeline in the **Secure cluster**: webhook builds OFF, PR builds OFF, branch limiting `v*`; paste `pipelines/promote/0_webui.yml` as its steps.
2. Put its UUID in `buildkite_ids.auto.tfvars` (the placeholder zero UUID fails terraform validation, so this is fail-closed).
3. `terraform apply`.
4. First use: promote v1.13.0-rc2 by creating a build with branch `v1.13.0-rc2`, then dispatch the CI workflow on JuliaLang/VersionsJSONUtil.jl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)