### PR TITLE
Backport #586 ("Fix release tag double build") to `release-1.12`

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -128,6 +128,15 @@ and which carry AWS session tags (`step_key`, `build_commit`, `pipeline_slug`, .
   that publish would consume. Build / PR jobs cannot touch release paths
   or sign anything. (Consumers, e.g. juliaup, map PR number → head sha
   via the GitHub API and fetch from the sha path in the `-pr` bucket.)
+  Staged names are always commit-keyed (`julia-<sha10>-<os>-<arch>`);
+  version names exist only at the final promote. A `v*` **tag** build is
+  an *independent* build of its commit that stages under an extra `tag/`
+  path flavor (`bin/<sha>/tag/…`): tag state is baked into build content
+  (`Base.VERSION` on prereleases, the install prefix), so pushing a
+  release branch and its tag — one build each, same commit — must not
+  let the branch build's artifacts stand in for the release. The
+  publish run picks the flavor (and its `TAR_VERSION` naming) from its
+  trigger's branch, which carries the tag name for tag builds.
 * **Tokens**: only `julia-ci` has a tokens role (`julia-oidc-tokens-ci`,
   SSM `ssm:GetParameter` on the telemetry tokens). There is deliberately
   no `-pr` counterpart: a pull request executes attacker-controlled code
@@ -139,6 +148,17 @@ and which carry AWS session tags (`step_key`, `build_commit`, `pipeline_slug`, .
   uploads of already-existing objects fail. The only exception is the
   `julia-latest-*` pointer objects, which release builds intentionally
   repoint. Object versioning on the bucket is recommended belt-and-braces.
+  Write-once is per *commit*, not per build: every object carries a
+  `build-commit` metadata stamp (the Buildkite-attested commit), and
+  `upload_to_s3.sh` treats an existing object from the same commit as
+  success (first upload wins). Builds are not byte-reproducible, so this
+  is what lets a rebuild of an already-staged commit, concurrent sibling
+  builds of the same commit sharing a key (the doctest htmldocs archive
+  during a release-branch + tag double build), and a re-run publish all
+  succeed idempotently instead of going red. A conflict across
+  *different* commits (e.g. a repointed release tag at the final
+  locations) is still a hard error; replacing published artifacts is a
+  deliberate manual operation.
 * Signing never exposes key material: every signature (macOS code signature,
   notarization JWT, GPG tarball signature, docs-deploy SSH authentication)
   is a `kms:Sign` call, conditioned on the calling job's step
@@ -320,9 +340,19 @@ The single publish step signs and packages for every OS on linux:
   Only the notary key uses KMS `EXTERNAL` (BYOK) import, because Apple
   generates App Store Connect API keys and we cannot register our own
   public key with Apple.
-* Retried upload jobs hitting an existing identical object are handled in
-  `utilities/upload_julia.sh` (412 + ETag comparison), not by allowing
-  overwrites.
+* Retried upload jobs hitting an existing object are handled in
+  `utilities/upload_to_s3.sh` (412, then ETag comparison for identical
+  content and the `build-commit` metadata stamp for a sibling build of
+  the same commit), not by allowing overwrites.
+* Re-running a release: use **Rebuild** on the `julia-ci` tag build, or
+  create a new `julia-ci` build with the branch set to the tag name
+  (`v<version>`) — both enter the release tag flow. To re-run just the
+  promote, POST a `julia-publish` build with the release commit and
+  `branch: v<version>` plus `ignore_pipeline_branch_filters: true`
+  (branch webhook builds are disabled on the publish pipeline); a plain
+  `branch: master` build of the same commit would promote it under
+  commit-hash (nightly) names instead. Already-promoted objects are
+  skipped via the same-commit rule above.
 * juliaup needs a change to consume PR binaries: resolve PR number → head
   sha via the GitHub API, then fetch
   `s3://julialang-ephemeral-pr/bin/<sha>/julia-*` (this replaces the old

--- a/pipelines/main/misc/deploy_docs.yml
+++ b/pipelines/main/misc/deploy_docs.yml
@@ -47,7 +47,14 @@ steps:
           # S3 grant (and no bucket-listing) is needed here. We still assume the
           # docs-deploy role below for the KMS-backed SSH signing of the push.
           source .buildkite/utilities/aws_oidc.sh docs-deploy
-          aws s3 cp "s3://${STAGING_BUCKET:-julialang-ephemeral-ci}/${S3_BUCKET_PREFIX:-bin}/${BUILDKITE_COMMIT}/julia-htmldocs.tar.gz" .
+          # For a tag-triggered publish (the trigger passes the tag name
+          # through as the branch), read the tag build's docs from the tag/
+          # staging flavor -- the counterpart of the doctest step's upload.
+          STAGING_FLAVOR=""
+          if [[ "$${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+              STAGING_FLAVOR="tag/"
+          fi
+          aws s3 cp "s3://${STAGING_BUCKET:-julialang-ephemeral-ci}/${S3_BUCKET_PREFIX:-bin}/${BUILDKITE_COMMIT}/$${STAGING_FLAVOR}julia-htmldocs.tar.gz" .
 
           echo "--- Configure SSH signing via AWS KMS"
           # The deploy key private half lives in AWS KMS and never leaves

--- a/pipelines/main/misc/doctest.yml
+++ b/pipelines/main/misc/doctest.yml
@@ -67,12 +67,23 @@ steps:
           fi
           source .buildkite/utilities/aws_oidc.sh stage
           source .buildkite/utilities/upload_to_s3.sh
+          # Release (v* tag) builds stage under the tag/ path flavor, like the
+          # binary tarballs: the docs are built by the tagged julia (their
+          # version strings embed its Base.VERSION), so the tag build's docs
+          # must not contend with the release-branch twin build's. Mirrors the
+          # RELEASE_TAG_FLOW predicate in build_envs.sh; misc/deploy_docs.yml
+          # selects the same flavor on download.
+          STAGING_FLAVOR=""
+          if [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == "julia-ci" ]] &&
+             [[ "$${BUILDKITE_TAG:-}" == v[0-9]* || "$${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+              STAGING_FLAVOR="tag/"
+          fi
           # Stage under a stable, version-independent key so the publish
           # pipeline's docs-deploy job can fetch it by exact key (a single
           # public GetObject -- the staging bucket is public-read) rather than
           # listing the bucket, which would need an S3 ListBucket grant.
           UPLOAD_TO_S3_ACL=none upload_to_s3 "doc/$${DOCUMENTER_ARCHIVE}" \
-              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/julia-htmldocs.tar.gz"
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/$${STAGING_FLAVOR}julia-htmldocs.tar.gz"
         env:
           # Give a fake documenter key to get Documenter to try and deploy for us
           DOCUMENTER_KEY: ""

--- a/utilities/build_envs.sh
+++ b/utilities/build_envs.sh
@@ -121,9 +121,58 @@ MAJMIN="$(cut -d. -f1-2 <<<"${JULIA_VERSION}")"
 MAJMINPAT="$(cut -d- -f1 <<<"${JULIA_VERSION}")"
 export JULIA_VERSION MAJMIN MAJMINPAT
 
-# If we're on a tag, then our "tar version" will be the julia version.
-# Otherwise, it's the short commit.
-if git describe --tags --exact-match >/dev/null 2>/dev/null; then
+# Is this job part of the RELEASE flow for a v* tag? True for the tag
+# build itself -- BUILDKITE_TAG is set uniformly on every job of a tag
+# build, and Buildkite reports the tag name as the branch, which also
+# covers a manual re-run created with branch=v<version> -- and for the
+# julia-publish run it triggers (the trigger passes the branch through,
+# pinned to the source build's by the cluster trigger rule). The
+# release-*/master build of the very same commit deliberately does NOT
+# count: the tag build is an independent build, and only ITS artifacts
+# are promoted to the versioned release locations (see STAGING_TARGET
+# below for why the two must not be interchangeable). Restricted to the
+# pipelines that feed releases so that e.g. a julia-pr branch that
+# happens to be named v2-something cannot enter the release flow.
+RELEASE_TAG_FLOW="false"
+case "${BUILDKITE_PIPELINE_SLUG:-}" in
+    julia-ci|julia-publish*)
+        if [[ "${BUILDKITE_TAG:-}" == v[0-9]* || "${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+            RELEASE_TAG_FLOW="true"
+        fi
+        ;;
+esac
+export RELEASE_TAG_FLOW
+
+# The release flow names everything after JULIA_VERSION (the VERSION
+# file), so a tag that disagrees with it would publish artifacts whose
+# names contradict their content. Fail loudly and early instead.
+if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+    RELEASE_TAG="${BUILDKITE_TAG:-${BUILDKITE_BRANCH}}"
+    if [[ "${RELEASE_TAG}" != "v${JULIA_VERSION}" ]]; then
+        echo "ERROR: release tag '${RELEASE_TAG}' does not match the VERSION file ('${JULIA_VERSION}')" >&2
+        exit 1
+    fi
+fi
+
+# TAR_VERSION is the version identity of the artifacts this job handles:
+# the julia version for the release flow, the short commit otherwise.
+if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-publish* ]]; then
+    # Publish naming follows the TRIGGER identity, never checkout state:
+    # whether this checkout happens to contain any given tag depends on
+    # what the agent fetched, and `git describe` here could pick up a tag
+    # that landed only after the triggering branch build (or miss the tag
+    # of a tag-triggered publish) -- either way promoting under names that
+    # do not match the staged artifacts' content.
+    if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+        TAR_VERSION="${JULIA_VERSION}"
+    else
+        TAR_VERSION="${SHORT_COMMIT}"
+    fi
+elif git describe --tags --exact-match >/dev/null 2>/dev/null; then
+    # Build pipelines must agree with what `make` produces from the same
+    # checkout (Make.inc derives the julia-$(JULIA_COMMIT) install prefix
+    # and the binary-dist name from the same `git describe`), so here the
+    # checkout state IS the right source.
     TAR_VERSION="${JULIA_VERSION}"
 else
     TAR_VERSION="${SHORT_COMMIT}"
@@ -293,7 +342,27 @@ export STAGING_BUCKET
 # attested value is the one that cannot drift from the IAM condition.
 # The publish trigger and deploy_docs pass BUILDKITE_COMMIT along, so
 # reads agree with what was staged.
-export STAGING_TARGET="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${UPLOAD_FILENAME}"
+#
+# The release (v* tag) flow stages under an additional tag/ path flavor,
+# because the tag build is an INDEPENDENT build of its commit: tag state
+# is baked into build CONTENT, not just names. Base.VERSION keeps the
+# build-number suffix on prereleases unless the tag was visible at build
+# time (base/version.jl: a pre-tag build reports v"1.13.0-rc2.77", the
+# tag build v"1.13.0-rc2"), and Make.inc derives the julia-$(JULIA_COMMIT)
+# install prefix from the same `git describe`. Pushing a release branch
+# and its tag together fires one build for EACH, for the same commit; the
+# flavor keeps the tag build's artifacts -- the only ones fit to become
+# the release -- from contending with (or losing a first-upload-wins race
+# to) the branch build's. The staged FILENAME is commit-keyed in both
+# flavors: version names are claimed only by the final promote
+# (UPLOAD_TARGETS above), so a repointed tag never leaves a stale
+# version-named object behind in staging.
+if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+    STAGING_FLAVOR="tag/"
+else
+    STAGING_FLAVOR=""
+fi
+export STAGING_TARGET="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${STAGING_FLAVOR}julia-${SHORT_COMMIT}-${OS?}-${ARCH?}"
 
 echo "--- Print the full and short commit hashes"
 echo "The full commit is:                      ${LONG_COMMIT}"

--- a/utilities/upload_to_s3.sh
+++ b/utilities/upload_to_s3.sh
@@ -15,13 +15,15 @@
 # from OIDC web identity (AWS_WEB_IDENTITY_TOKEN_FILE / AWS_ROLE_ARN).
 export AWS_EC2_METADATA_DISABLED=true
 
-# Upload a local file to `s3://${BUCKET}/${KEY}`, write-once.
+# Upload a local file to `s3://${BUCKET}/${KEY}`, write-once per commit.
 #
 # IAM denies unconditional puts, so a build can never overwrite an existing
 # object (S3 conditional write, If-None-Match: *). If the object already
-# exists (e.g. a retried job) we accept it iff its content matches what we
-# have locally. `julia-latest-*` pointer objects are intentionally
-# overwritten (and only the publish role is allowed to do so).
+# exists we accept it iff its content matches what we have locally (a
+# retried job re-uploading the same bytes), OR iff it was uploaded by
+# another build of the same commit (see below). `julia-latest-*` pointer
+# objects are intentionally overwritten (and only the publish role is
+# allowed to do so).
 upload_to_s3() {
     local file="$1" target="$2"
     local bucket="${target%%/*}"
@@ -32,6 +34,16 @@ upload_to_s3() {
         acl_args=()
     fi
 
+    # Stamp every object with the commit that produced it. BUILDKITE_COMMIT
+    # is the same Buildkite-attested value that gates the staging paths and
+    # that verify_trusted_commit.sh checks before a publish, so the stamp is
+    # trustworthy provenance -- and it is what lets a second build of the
+    # SAME commit be treated as idempotent below.
+    local metadata_args=()
+    if [[ "${BUILDKITE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]]; then
+        metadata_args=( --metadata "build-commit=${BUILDKITE_COMMIT}" )
+    fi
+
     # Debug/test stacks (UPLOAD_TO_S3_OVERWRITE=1) re-publish the same commit
     # repeatedly, so they overwrite unconditionally. This can only ever succeed
     # against a bucket whose role permits an unconditional PutObject -- the
@@ -40,7 +52,8 @@ upload_to_s3() {
     if [[ "${UPLOAD_TO_S3_OVERWRITE:-0}" == "1" || "$(basename "${key}")" == julia-latest-* ]]; then
         aws s3api put-object \
             --bucket "${bucket}" --key "${key}" \
-            --body "${file}" ${acl_args[@]+"${acl_args[@]}"} >/dev/null
+            --body "${file}" ${acl_args[@]+"${acl_args[@]}"} \
+            ${metadata_args[@]+"${metadata_args[@]}"} >/dev/null
         echo "uploaded (overwrite): s3://${target}"
         return 0
     fi
@@ -49,21 +62,46 @@ upload_to_s3() {
     if output="$(aws s3api put-object \
             --bucket "${bucket}" --key "${key}" \
             --body "${file}" ${acl_args[@]+"${acl_args[@]}"} \
+            ${metadata_args[@]+"${metadata_args[@]}"} \
             --if-none-match '*' 2>&1)"; then
         echo "uploaded (write-once): s3://${target}"
         return 0
     fi
 
     if [[ "${output}" == *"PreconditionFailed"* || "${output}" == *"412"* ]]; then
-        local local_md5 remote_etag
+        local remote_info local_md5 remote_etag remote_commit
         local_md5="$(openssl dgst -md5 -r "${file}" | cut -d' ' -f1)"
-        remote_etag="$(aws s3api head-object --bucket "${bucket}" --key "${key}" \
-            --query ETag --output text | tr -d '"')"
+        remote_info="$(aws s3api head-object --bucket "${bucket}" --key "${key}" \
+            --query '[ETag, Metadata."build-commit"]' --output text)"
+        remote_etag="$(cut -f1 <<<"${remote_info}" | tr -d '"')"
+        remote_commit="$(cut -f2 <<<"${remote_info}")"
+        # `--output text` renders a missing metadata entry as literal "None"
+        [[ "${remote_commit}" == "None" ]] && remote_commit=""
         if [[ "${local_md5}" == "${remote_etag}" ]]; then
             echo "already exists with identical content, skipping: s3://${target}"
             return 0
         fi
-        echo "ERROR: s3://${target} already exists with DIFFERENT content; refusing to overwrite" >&2
+        # Julia builds are not byte-reproducible, so two builds of the same
+        # commit legitimately produce different bytes for the same object.
+        # That happens in normal operation: a rebuild of a commit whose
+        # artifacts are already staged, a build that shares a staging key
+        # with a concurrent sibling of the same commit (the doctest
+        # htmldocs archive during a release-branch + tag double build), or
+        # a re-run publish re-signing artifacts whose predecessors were
+        # already promoted. Every writer of a given location is equally
+        # trusted for a given commit -- staging paths are IAM-gated to the
+        # attested build commit, and the final locations are writable only by
+        # the publish role after the trusted-commit check -- so if the
+        # existing object came from this same commit, keep it and succeed:
+        # first upload wins. Anything else (in particular a repointed release
+        # tag, where a version name suddenly maps to a different commit)
+        # stays a hard error: replacing a published object is a deliberate
+        # manual operation.
+        if [[ "${BUILDKITE_COMMIT:-}" =~ ^[0-9a-f]{40}$ && "${remote_commit}" == "${BUILDKITE_COMMIT}" ]]; then
+            echo "already uploaded by another build of commit ${BUILDKITE_COMMIT:0:10}, keeping the existing object: s3://${target}"
+            return 0
+        fi
+        echo "ERROR: s3://${target} already exists with DIFFERENT content (from build-commit: ${remote_commit:-unknown}); refusing to overwrite" >&2
         return 1
     fi
 


### PR DESCRIPTION
This backports #586 to `release-1.12`, so that the next 1.12.x point release tag goes through the release tag flow (single build, `tag/` staging flavor, version-named publish). Same cherry-pick as #588 on `release-1.13`.

- [x] #586

(cherry picked from commit 83a080c65268437a2ba82f39a99933118bee72fd)