### PR TITLE
Backport #593 (release source dists) to `release-1.13`

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -64,6 +64,12 @@ publish trigger, exactly like `julia-pr`.
    (TRUSTED: role julia-oidc-publish, kms:Sign + read julia-ci staging bucket
     ONLY + write final)
    verify_trusted_commit.sh → sign (rcodesign / Trusted Signing / KMS-GPG) → promote → deploy docs
+
+ For release (v*) tag builds, julia-ci additionally builds the light/full
+ source dists (misc/source_dist.yml) and stages them alongside the
+ binaries; publish_srcdist.sh KMS-signs them and publishes to
+ bin/src/<majmin>/ in the nightlies bucket, and julia-promote copies them
+ to the release bucket and includes them in the checksums files.
 ```
 
 Why this is safe where branch-pinning was not: Buildkite reports a pull

--- a/pipelines/main/misc/source_dist.yml
+++ b/pipelines/main/misc/source_dist.yml
@@ -1,0 +1,79 @@
+steps:
+  - group: "Check"
+    steps:
+      - label: "source dist"
+        key: source_dist
+        # Release tag flow only (mirrors RELEASE_TAG_FLOW in build_envs.sh):
+        # source dists are published per release, not per commit, and this
+        # step costs a docs build plus a full deps download.
+        if: pipeline.slug == "julia-ci" && (build.tag =~ /^v[0-9]/ || build.branch =~ /^v[0-9]/)
+        depends_on:
+          - "build_x86_64-linux-gnu"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              # Host julia, required by the sandbox plugin; the docs are built
+              # with the freshly-built julia downloaded below.
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.11' # GREP_ME: Keep this updated. Do not set it to '1' or 'stable' or 'latest'.
+          - JuliaCI/sandbox#v2:
+              rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v8.5/package_linux.x86_64.tar.gz
+              rootfs_treehash: "8b46765146862479f0a8946f2ef783a8bf93b20f"
+              uid: 1000
+              gid: 1000
+              workspaces:
+                # Include `/cache/repos` so that our `git` version introspection works.
+                - "/cache/repos:/cache/repos"
+        commands: |
+          # Download pre-built julia, extract into `usr/` (the in-tree
+          # build_bindir), so `make -C doc html` finds a julia to run
+          # Documenter with -- no compilation happens in this step.
+          buildkite-agent artifact download --step "build_x86_64-linux-gnu" 'julia-*-linux-x86_64.tar.gz' .
+          mkdir -p ./usr
+          tar -C ./usr --strip-components=1 -zxf julia-*-linux-x86_64.tar.gz
+          rm -f julia-*-linux-x86_64.tar.gz
+
+          echo "--- Build HTML docs (bundled into the source dists)"
+          make --output-sync -C doc html
+
+          echo "--- Build source distribution tarballs"
+          # JULIA_COMMIT is overridden to the version so the in-tarball prefix
+          # is julia-<version>/ even when the agent checkout cannot resolve
+          # the tag (a branch build of the tag commit). Release source
+          # tarballs have always used the version prefix.
+          V="$$(cat VERSION)"
+          make light-source-dist full-source-dist JULIA_COMMIT="$${V}"
+          mv "julia-$${V}_$${V}.tar.gz" "julia-$${V}.tar.gz"
+          mv "julia-$${V}_$${V}-full.tar.gz" "julia-$${V}-full.tar.gz"
+          sha256sum "julia-$${V}.tar.gz" "julia-$${V}-full.tar.gz"
+
+          echo "--- Stage source dists to S3 for the publish pipeline"
+          # Mirror the doctest htmldocs handoff: a write-once upload to this
+          # build's commit-sha-gated staging path via the untrusted `stage`
+          # role, under stable version-independent keys so the publish
+          # pipeline can fetch them by exact key (single public GetObject,
+          # no bucket listing). publish_srcdist.sh reads them back, signs,
+          # and uploads to the canonical locations.
+          if [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
+              STAGING_BUCKET="julialang-ephemeral-pr"
+          elif [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
+              STAGING_BUCKET="julialang-ephemeral-buildkite"
+          else
+              STAGING_BUCKET="julialang-ephemeral-ci"
+          fi
+          source .buildkite/utilities/aws_oidc.sh stage
+          source .buildkite/utilities/upload_to_s3.sh
+          # Always the tag/ staging flavor: the `if:` above restricts this
+          # step to the release tag flow (see STAGING_FLAVOR in build_envs.sh).
+          UPLOAD_TO_S3_ACL=none upload_to_s3 "julia-$${V}.tar.gz" \
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/tag/julia-srcdist.tar.gz"
+          UPLOAD_TO_S3_ACL=none upload_to_s3 "julia-$${V}-full.tar.gz" \
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/tag/julia-srcdist-full.tar.gz"
+        timeout_in_minutes: 120
+        agents:
+          queue: "test"
+          sandbox_capable: "true"
+          os: "linux"
+          arch: "x86_64"

--- a/utilities/publish.sh
+++ b/utilities/publish.sh
@@ -74,8 +74,16 @@ for triplet in "${TRIPLETS[@]}"; do
     fi
 done
 
+echo "+++ Publish source dists"
+# shellcheck source=SCRIPTDIR/aws_oidc.sh
+source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE}"
+if ! bash .buildkite/utilities/publish_srcdist.sh; then
+    echo "ERROR: publishing source dists failed" >&2
+    FAILED+=( "srcdist" )
+fi
+
 if [[ "${#FAILED[@]}" -gt 0 ]]; then
-    echo "--- ${#FAILED[@]} triplet(s) failed to publish: ${FAILED[*]}" >&2
+    echo "--- ${#FAILED[@]} item(s) failed to publish: ${FAILED[*]}" >&2
     exit 1
 fi
 

--- a/utilities/publish_srcdist.sh
+++ b/utilities/publish_srcdist.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Sign and publish the source distribution tarballs (release tag flow only).
+#
+# The build pipeline's source_dist step staged the light and full source
+# dists under this commit's tag/ staging path. Download them, GPG-sign via
+# KMS (same key and mechanism as the binary tarballs, see upload_julia.sh),
+# and upload to bin/src/<majmin>/ in the nightlies bucket. julia-promote
+# then copies them to the release bucket alongside the binaries.
+#
+# Invoked by publish.sh after the per-triplet loop, with the publish role
+# already assumed. Standalone invocation also works (it re-establishes the
+# guard + role itself, like upload_julia.sh).
+set -euo pipefail
+
+# build_envs.sh derives per-platform variables from TRIPLET; the source
+# dists are platform-independent, so pin any valid triplet -- only the
+# version / flow / bucket variables are used here.
+export TRIPLET="${TRIPLET:-x86_64-linux-gnu}"
+# shellcheck source=SCRIPTDIR/build_envs.sh
+source .buildkite/utilities/build_envs.sh
+# shellcheck source=SCRIPTDIR/upload_to_s3.sh
+source .buildkite/utilities/upload_to_s3.sh
+
+if [[ "${RELEASE_TAG_FLOW}" != "true" ]]; then
+    echo "Not a release tag build; no source dists to publish."
+    exit 0
+fi
+
+if [[ -z "${PUBLISH_PREAUTHED:-}" ]]; then
+    echo "--- Verify this is a trusted release commit"
+    bash .buildkite/utilities/verify_trusted_commit.sh
+    # shellcheck source=SCRIPTDIR/aws_oidc.sh
+    source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE:-publish}"
+fi
+
+# Same KMS key / pubkey selection as upload_julia.sh (the non-production
+# publish test stack overrides these).
+TARBALL_SIGNING_KMS_KEY="${TARBALL_SIGNING_KMS_KEY:-alias/julia-tarball-signing}"
+TARBALL_SIGNING_PUBKEY="${TARBALL_SIGNING_PUBKEY-.buildkite/signing-pubkeys/tarball_signing.pub.asc}"
+if [[ -n "${TARBALL_SIGNING_PUBKEY}" ]]; then
+    GPG_PUBKEY_ARGS=( --public-key "${TARBALL_SIGNING_PUBKEY}" )
+else
+    GPG_PUBKEY_ARGS=( --public-key-from-kms )
+    [[ -n "${TARBALL_SIGNING_PUBKEY_CREATED:-}" ]] && GPG_PUBKEY_ARGS+=( --created "${TARBALL_SIGNING_PUBKEY_CREATED}" )
+fi
+
+STAGING_PREFIX="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${STAGING_FLAVOR}"
+
+# Tag builds from before the source_dist step exist(ed) have nothing
+# staged; a re-publish of such a tag must not fail on that.
+if ! aws s3api head-object --bucket "${STAGING_BUCKET}" \
+        --key "${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT}/${STAGING_FLAVOR}julia-srcdist.tar.gz" >/dev/null 2>&1; then
+    echo "WARN: no staged source dists at s3://${STAGING_PREFIX}julia-srcdist.tar.gz; skipping." >&2
+    exit 0
+fi
+
+for SUFFIX in "" "-full"; do
+    STAGED="julia-srcdist${SUFFIX}.tar.gz"
+    FINAL="julia-${JULIA_VERSION}${SUFFIX}.tar.gz"
+
+    echo "--- Download staged ${STAGED} from s3://${STAGING_PREFIX}${STAGED}"
+    aws s3 cp --only-show-errors "s3://${STAGING_PREFIX}${STAGED}" "${FINAL}"
+
+    # The in-tarball prefix is part of the published interface: releases
+    # extract to julia-<version>/ (source_dist.yml pins JULIA_COMMIT).
+    FIRST_ENTRY="$(tar -tzf "${FINAL}" | head -1)"
+    if [[ "${FIRST_ENTRY}" != "julia-${JULIA_VERSION}/"* ]]; then
+        echo "ERROR: ${FINAL} does not extract to julia-${JULIA_VERSION}/ (first entry: ${FIRST_ENTRY})" >&2
+        exit 1
+    fi
+
+    echo "--- GPG-sign ${FINAL}"
+    python3 .buildkite/utilities/kms_gpg_sign.py \
+        "${GPG_PUBKEY_ARGS[@]}" \
+        --kms-key-id "${TARBALL_SIGNING_KMS_KEY}" \
+        "${FINAL}"
+
+    echo "--- Upload ${FINAL} to s3://${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/"
+    upload_to_s3 "${FINAL}" "${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/${FINAL}"
+    upload_to_s3 "${FINAL}.asc" "${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/${FINAL}.asc"
+done
+
+echo "+++ Published source dists"
+for SUFFIX in "" "-full"; do
+    echo " -> s3://${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/julia-${JULIA_VERSION}${SUFFIX}.tar.gz"
+done

--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -344,6 +344,7 @@ OMITTED_POWERPC = [
 CHECK_STATIC = [
     "analyzegc.yml",
     "doctest.yml",
+    "source_dist.yml",
     "pdf_docs/build_pdf_docs.yml",
     "embedding.yml",
     "trimming.yml",


### PR DESCRIPTION
This backports #593 to `release-1.13`. Merge after #593.

`julia-ci` and `julia-publish` load their steps from the julia checkout's `.buildkite-external-version` pin, which is `release-1.13` on the release branch — so the source-dist step and `publish_srcdist.sh` must be on this branch for v1.13.x tags, including the planned v1.13.0-rc2 source-dist backfill.

The `promote_release.sh` part of #593 is excluded: `julia-promote` deliberately tracks `main` (see `pipelines/promote/0_webui.yml`), so the promotion side needs no backport.

- [ ] #593

(cherry picked from commit 7427763795b46b4f61ed2704d334390dd418aa13)