### PR TITLE
utilities: fix silent SIGPIPE death in the srcdist prefix check

### DIFF
--- a/utilities/publish_srcdist.sh
+++ b/utilities/publish_srcdist.sh
@@ -63,7 +63,10 @@ for SUFFIX in "" "-full"; do
 
     # The in-tarball prefix is part of the published interface: releases
     # extract to julia-<version>/ (source_dist.yml pins JULIA_COMMIT).
-    FIRST_ENTRY="$(tar -tzf "${FINAL}" | head -1)"
+    # head closing the pipe SIGPIPEs tar (silent exit 141 under pipefail);
+    # mask tar's status -- a bad tarball yields an empty/garbage FIRST_ENTRY
+    # that the prefix check below rejects.
+    FIRST_ENTRY="$( (tar -tzf "${FINAL}" || true) | head -1)"
     if [[ "${FIRST_ENTRY}" != "julia-${JULIA_VERSION}/"* ]]; then
         echo "ERROR: ${FINAL} does not extract to julia-${JULIA_VERSION}/ (first entry: ${FIRST_ENTRY})" >&2
         exit 1


### PR DESCRIPTION
`tar -tzf | head -1` in publish_srcdist.sh's prefix check SIGPIPEs GNU tar when `head` closes the pipe: silent exit 141 under pipefail, which killed the first srcdist publish attempt ([julia-publish 147](https://buildkite.com/julialang/julia-publish/builds/147)) right after the staged download with nothing in the log. Mask tar's exit status inside the substitution — a genuinely bad tarball still fails via the prefix check on the empty first entry.

Already on `release-1.13` via #602 and used in the successful v1.13.0-rc2 backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)