### PR TITLE
Backport lapack srccache pre-seed to `release-1.13`

### DIFF
--- a/pipelines/main/misc/source_dist.yml
+++ b/pipelines/main/misc/source_dist.yml
@@ -44,6 +44,14 @@ steps:
           # the tag (a branch build of the tag commit). Release source
           # tarballs have always used the version prefix.
           V="$$(cat VERSION)"
+          # netlib renamed lapack-<ver>.tgz to .tar.gz (byte-identical) and
+          # the old name 404s; pre-seed the srccache under the name the tree
+          # expects. Best-effort: on failure make tries its own URL as before.
+          LAPACK_VER="$$(sed -n 's/^LAPACK_VER := //p' deps/openblas.version)"
+          mkdir -p deps/srccache
+          curl -fSsL -o "deps/srccache/lapack-$${LAPACK_VER}.tgz" \
+              "https://www.netlib.org/lapack/lapack-$${LAPACK_VER}.tar.gz" \
+              || rm -f "deps/srccache/lapack-$${LAPACK_VER}.tgz"
           # FC=gcc satisfies Make.inc's gfortran presence check; the getall
           # sub-targets only download source tarballs and never run fortran,
           # and the rootfs has no gfortran.


### PR DESCRIPTION
netlib renamed `lapack-<ver>.tgz` to `lapack-<ver>.tar.gz` (byte-identical content, verified against the copy shipped in the v1.13.0-rc1 full source dist) and the old URL now returns 404, which broke `full-source-dist` in [julia-ci build 264](https://buildkite.com/julialang/julia-ci/builds/264#019ff7b8-16ee-4487-892c-1e9740cff99e). Tagged julia trees reference the old name, so download the new name into srccache before running make; on failure make falls back to its own URL as before.

Backport of the second commit on #597.