### PR TITLE
publish: speed up the publish and docs-deploy jobs

### DIFF
--- a/pipelines/main/misc/deploy_docs.yml
+++ b/pipelines/main/misc/deploy_docs.yml
@@ -68,7 +68,10 @@ steps:
           echo "--- clone docs.julialang.org"
           mkdir -p /home/juliaci/.ssh
           ssh-keyscan github.com >> /home/juliaci/.ssh/known_hosts 2>/dev/null
-          git clone git@github.com:JuliaLang/docs.julialang.org -b gh-pages repo
+          # Shallow clone: only the tip tree is needed to build the next
+          # commit, and pushing from a shallow clone works because the new
+          # commit's parent is the remote tip.
+          git clone --depth 1 -b gh-pages git@github.com:JuliaLang/docs.julialang.org repo
           cd repo
 
           echo "--- deploy new docs"

--- a/utilities/macos/build_dmg.sh
+++ b/utilities/macos/build_dmg.sh
@@ -117,15 +117,34 @@ create_dmg
 if [[ "${PUBLISH_SKIP_NOTARIZATION:-0}" != "1" ]]; then
     RCODESIGN="$("${THIS_DIR}/get_rcodesign.sh")"
 
-    "${RCODESIGN}" notary-submit \
-        --api-key-file "${NOTARY_API_KEY_FILE}" \
-        --wait \
-        "${DMG_NAME}"
+    if [[ -n "${NOTARY_DEFER_DIR:-}" ]]; then
+        # Deferred mode (publish.sh): only submit -- Apple processes while
+        # the remaining triplets publish, and publish.sh waits/staples/
+        # uploads in its final phase. Without --wait, notary-submit returns
+        # after the upload, logging "created submission ID: <uuid>" to
+        # stderr; record that ID.
+        SUBMIT_LOG="$(mktemp)"
+        "${RCODESIGN}" notary-submit \
+            --api-key-file "${NOTARY_API_KEY_FILE}" \
+            "${DMG_NAME}" 2>&1 | tee "${SUBMIT_LOG}"
+        SUBMISSION_ID="$(sed -n 's/.*created submission ID: \([0-9a-fA-F-]*\).*/\1/p' "${SUBMIT_LOG}" | head -n1)"
+        rm -f "${SUBMIT_LOG}"
+        if [[ -z "${SUBMISSION_ID}" ]]; then
+            echo "ERROR: could not parse the notary submission ID from rcodesign output" >&2
+            exit 1
+        fi
+        printf '%s\n' "${SUBMISSION_ID}" > "${NOTARY_DEFER_DIR}/${UPLOAD_FILENAME}.submission"
+    else
+        "${RCODESIGN}" notary-submit \
+            --api-key-file "${NOTARY_API_KEY_FILE}" \
+            --wait \
+            "${DMG_NAME}"
 
-    # Staple the ticket onto the .dmg itself -- no rebuild needed. The stapled
-    # .dmg validates offline on download; Gatekeeper then assesses the .app when
-    # it is first launched from the mounted volume.
-    "${RCODESIGN}" staple "${DMG_NAME}"
+        # Staple the ticket onto the .dmg itself -- no rebuild needed. The stapled
+        # .dmg validates offline on download; Gatekeeper then assesses the .app when
+        # it is first launched from the mounted volume.
+        "${RCODESIGN}" staple "${DMG_NAME}"
+    fi
 else
     echo "Skipping notarization (PUBLISH_SKIP_NOTARIZATION=1): .dmg is KMS-signed but not notarized/stapled." >&2
 fi

--- a/utilities/publish.sh
+++ b/utilities/publish.sh
@@ -48,6 +48,15 @@ bash .buildkite/utilities/verify_trusted_commit.sh
 # step can run longer across all triplets.
 export PUBLISH_PREAUTHED=1
 
+# macOS notarization is deferred: build_dmg.sh only submits each dmg to
+# Apple and records the submission here, so Apple's processing overlaps the
+# remaining triplets. ALL of a macOS triplet's products (.tar.gz, .tar.gz.asc,
+# .dmg -- they share the signed tree Apple is judging) are withheld until the
+# final phase below, which waits, staples and only then promotes.
+NOTARY_DEFER_DIR="$(mktemp -d)"
+export NOTARY_DEFER_DIR
+trap 'rm -rf "${NOTARY_DEFER_DIR}"' EXIT
+
 # Collect all triplets from the arches files.
 TRIPLETS=()
 for arches in "${ARCHES_FILES[@]}"; do
@@ -86,6 +95,62 @@ source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE}"
 if ! bash .buildkite/utilities/publish_srcdist.sh; then
     echo "ERROR: publishing source dists failed" >&2
     FAILED+=( "srcdist" )
+fi
+
+# Deferred macOS triplets: collect Apple's verdicts, staple, and promote.
+# Each .deferinfo (written by upload_julia.sh) is: submission ID, then one
+# "<local path>\t<s3 target>" pair per line covering EVERY product of the
+# triplet (.tar.gz, .tar.gz.asc, .dmg) -- nothing macOS was promoted before
+# this point, so a rejected notarization publishes nothing (the final
+# locations are write-once and could not be repaired by a retry).
+shopt -s nullglob
+DEFERRED_MACOS=( "${NOTARY_DEFER_DIR}"/*.deferinfo )
+shopt -u nullglob
+if [[ "${#DEFERRED_MACOS[@]}" -gt 0 ]]; then
+    echo "+++ Notarize + publish ${#DEFERRED_MACOS[@]} deferred macOS triplet(s)"
+    # Fresh credentials: the previous token may be near its lifetime limit.
+    # shellcheck source=SCRIPTDIR/aws_oidc.sh
+    source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE}"
+    # shellcheck source=SCRIPTDIR/upload_to_s3.sh
+    source .buildkite/utilities/upload_to_s3.sh
+    RCODESIGN="$(bash .buildkite/utilities/macos/get_rcodesign.sh)"
+    NOTARY_API_KEY_FILE=".buildkite/utilities/macos/notary_api_key.json"
+    for info in "${DEFERRED_MACOS[@]}"; do
+        mapfile -t rec < "${info}"
+        submission_id="${rec[0]}"
+        files=()
+        targets=()
+        dmg_path=""
+        for line in "${rec[@]:1}"; do
+            files+=( "${line%%$'\t'*}" )
+            targets+=( "${line#*$'\t'}" )
+            [[ "${line%%$'\t'*}" == *.dmg ]] && dmg_path="${line%%$'\t'*}"
+        done
+        name="$(basename "${info}" .deferinfo)"
+        echo "--- Notarize + staple + publish ${name}"
+        # notary-wait exits 0 even for a rejected submission; the staple is
+        # the success gate (a rejected submission has no ticket to staple).
+        if ! "${RCODESIGN}" notary-wait --max-wait-seconds 1800 \
+                --api-key-file "${NOTARY_API_KEY_FILE}" "${submission_id}" \
+            || ! "${RCODESIGN}" staple "${dmg_path}"; then
+            echo "ERROR: notarizing/stapling ${name} failed; withholding all its products" >&2
+            FAILED+=( "${name}" )
+            continue
+        fi
+        upload_ok=1
+        PIDS=()
+        for i in "${!files[@]}"; do
+            upload_to_s3 "${files[$i]}" "${targets[$i]}" &
+            PIDS+=( "$!" )
+        done
+        for pid in "${PIDS[@]}"; do
+            wait "${pid}" || upload_ok=0
+        done
+        if [[ "${upload_ok}" -ne 1 ]]; then
+            echo "ERROR: publishing ${name} failed" >&2
+            FAILED+=( "${name}" )
+        fi
+    done
 fi
 
 if [[ "${#FAILED[@]}" -gt 0 ]]; then

--- a/utilities/upload_julia.sh
+++ b/utilities/upload_julia.sh
@@ -48,6 +48,18 @@ wait_pids() {
     done
 }
 
+# Create a .tar.gz, parallel-compressed with pigz when available (pigz is
+# not a hard dependency -- fall back to plain gzip).
+make_targz() {
+    local out="$1"
+    shift
+    if command -v pigz >/dev/null 2>&1; then
+        tar -I pigz -cf "${out}" "$@"
+    else
+        tar -zcf "${out}" "$@"
+    fi
+}
+
 if [[ "${MODE}" != "publish" ]]; then
     echo "ERROR: unknown mode '${MODE}' (expected 'publish')" >&2
     exit 1
@@ -143,7 +155,7 @@ if [[ "${OS}" == "macos" || "${OS}" == "macosnogpl" ]]; then
     rm -rf "${JULIA_INSTALL_DIR}"
     cp -aR "${APP_NAME}/Contents/Resources/julia" "${JULIA_INSTALL_DIR}"
     rm -f "${UPLOAD_FILENAME}.tar.gz"
-    tar zcf "${UPLOAD_FILENAME}.tar.gz" "${JULIA_INSTALL_DIR}"
+    make_targz "${UPLOAD_FILENAME}.tar.gz" "${JULIA_INSTALL_DIR}"
 
     # Build the `.dmg` from the signed .app (notarization gated by
     # PUBLISH_SKIP_NOTARIZATION inside build_dmg.sh).
@@ -151,7 +163,18 @@ if [[ "${OS}" == "macos" || "${OS}" == "macosnogpl" ]]; then
     MACOS_CODESIGN_KMS_KEY="${MACOS_CODESIGN_KMS_KEY}" APP_PATH="${APP_NAME}" \
         .buildkite/utilities/macos/build_dmg.sh
 
-    UPLOAD_EXTENSIONS+=( "dmg" )
+    if [[ -n "${NOTARY_DEFER_DIR:-}" && "${PUBLISH_SKIP_NOTARIZATION:-0}" != "1" ]]; then
+        # Deferred notarization (publish.sh): build_dmg.sh only submitted the
+        # dmg to Apple, so nothing is stapled yet. Withhold ALL macOS products
+        # from the promote step below, not just the dmg: the .tar.gz contains
+        # the exact signed tree Apple is judging, and the final locations are
+        # write-once (a rejected signature must not leave an unrepairable
+        # public object). The defer record for publish.sh is written at the
+        # promote step, once the .tar.gz.asc exists too.
+        NOTARY_DEFERRED=1
+    else
+        UPLOAD_EXTENSIONS+=( "dmg" )
+    fi
 elif [[ "${OS}" == "windows" || "${OS}" == "windowsnogpl" ]]; then
     echo "--- [windows] Extract pre-built Julia"
     # JULIA_INSTALL_DIR is shared across the triplets published sequentially
@@ -230,14 +253,15 @@ elif [[ "${OS}" == "windows" || "${OS}" == "windowsnogpl" ]]; then
     # Immediately re-compress that tarball for upload
     echo "--- [windows] Re-compress codesigned tarball"
     rm -f "${UPLOAD_FILENAME}.tar.gz"
-    tar zcf "${UPLOAD_FILENAME}.tar.gz" "${JULIA_INSTALL_DIR}"
+    make_targz "${UPLOAD_FILENAME}.tar.gz" "${JULIA_INSTALL_DIR}"
 
     # Use 7z (p7zip) to create a `.zip` file to upload as well
     echo "--- [windows] make zip"
     # `7z a` merges into an existing archive; start fresh so a leftover zip
     # from an earlier run in the same workdir can't contribute stale entries.
     rm -f "${UPLOAD_FILENAME}.zip"
-    7z a "${UPLOAD_FILENAME}.zip" "${JULIA_INSTALL_DIR}"
+    # -mmt=on: compress entries in parallel
+    7z a -mmt=on "${UPLOAD_FILENAME}.zip" "${JULIA_INSTALL_DIR}"
     UPLOAD_EXTENSIONS+=( "zip" )
 fi
 
@@ -260,6 +284,30 @@ python3 .buildkite/utilities/kms_gpg_sign.py \
     --kms-key-id "${TARBALL_SIGNING_KMS_KEY}" \
     "${UPLOAD_FILENAME}.tar.gz"
 UPLOAD_EXTENSIONS+=( "tar.gz.asc" )
+
+# Deferred notarization: promote NOTHING for this triplet yet. Record the
+# submission ID plus a "<local path>\t<s3 target>" pair for every product;
+# publish.sh waits for Apple's verdict, staples the dmg, and only then
+# uploads everything in its final phase.
+if [[ -n "${NOTARY_DEFERRED:-}" ]]; then
+    UPLOAD_EXTENSIONS+=( "dmg" )
+    {
+        cat "${NOTARY_DEFER_DIR}/${UPLOAD_FILENAME}.submission"
+        for EXT in "${UPLOAD_EXTENSIONS[@]}"; do
+            for UPLOAD_TARGET in "${UPLOAD_TARGETS[@]}"; do
+                printf '%s\t%s\n' "$(realpath "${UPLOAD_FILENAME}.${EXT}")" "${UPLOAD_TARGET}.${EXT}"
+            done
+        done
+    } > "${NOTARY_DEFER_DIR}/${UPLOAD_FILENAME}.deferinfo"
+
+    echo "+++ Deferred until notarization succeeds"
+    for UPLOAD_TARGET in "${UPLOAD_TARGETS[@]}"; do
+        for EXT in "${UPLOAD_EXTENSIONS[@]}"; do
+            echo " (deferred) s3://${UPLOAD_TARGET}.${EXT}"
+        done
+    done
+    exit 0
+fi
 
 # Promote to all final S3 targets (each target gets a direct upload of the
 # local file; no bucket-to-bucket copies, since write-once enforcement only

--- a/utilities/verify_trusted_commit.sh
+++ b/utilities/verify_trusted_commit.sh
@@ -29,20 +29,28 @@ trap 'rm -rf "${WORK}"' EXIT
 export GIT_DIR="${WORK}/repo.git"
 git init -q --bare "${GIT_DIR}"
 
+# Treeless fetches (--filter=tree:0): the reachability checks below only walk
+# commit (and tag) objects, so trees and blobs are never needed. The filter
+# requires a promisor remote, hence the named remote; refs still come fresh
+# from CANONICAL_URL.
+git remote add up "${CANONICAL_URL}"
+git config core.repositoryformatversion 1
+git config extensions.partialclone up
+
 echo "--- Verify ${COMMIT:0:12} is on a protected ref of ${CANONICAL_URL}"
 
 # Fetch only the protected refs from the canonical upstream. A commit that
 # only exists on a fork / PR branch will not be reachable from any of these.
-git fetch -q --no-tags "${CANONICAL_URL}" \
+git fetch -q --no-tags --filter=tree:0 up \
     "refs/heads/master:refs/remotes/up/master" \
     "refs/heads/release-*:refs/remotes/up/release/*" || true
 # Tags separately (release builds), into refs/tags/
-git fetch -q "${CANONICAL_URL}" "refs/tags/v*:refs/tags/v*" || true
+git fetch -q --filter=tree:0 up "refs/tags/v*:refs/tags/v*" || true
 
 # Make sure we actually have the commit object locally (fetch it directly if
 # the ref fetch above did not bring it in, e.g. very fresh master tip).
 if ! git cat-file -e "${COMMIT}^{commit}" 2>/dev/null; then
-    git fetch -q "${CANONICAL_URL}" "${COMMIT}" 2>/dev/null || true
+    git fetch -q --filter=tree:0 up "${COMMIT}" 2>/dev/null || true
 fi
 
 is_reachable() {

--- a/utilities/windows/build-installer.iss
+++ b/utilities/windows/build-installer.iss
@@ -66,6 +66,11 @@ PrivilegesRequiredOverridesAllowed=commandline
 WizardStyle=modern
 Compression=lzma2/ultra
 SolidCompression=yes
+; Parallel lzma2 block compression (slightly worse ratio, much faster); the
+; separate 64-bit compressor process avoids the 32-bit compiler's memory
+; ceiling on multiple ultra-dictionary block threads.
+LZMAUseSeparateProcess=yes
+LZMANumBlockThreads=4
 DefaultDirName={autopf}\{#DirName}
 UsePreviousPrivileges=no
 PrivilegesRequired=lowest


### PR DESCRIPTION
Wall-clock analysis of a `julia-publish` build (https://buildkite.com/julialang/julia-publish/builds/146) showed the `publish all` job dominated by serialized compression and notarization waits, plus the `upload docs` job holding a secure agent for a full-history clone of docs.julialang.org. This PR addresses all of it:

- **deploy_docs**: shallow-clone docs.julialang.org (`--depth 1`). The gh-pages history is multi-GB (one commit per deploy) and only the tip tree is needed to build the next commit; pushing from a shallow clone works because the new commit's parent is the remote tip.
- **Inno Setup**: `LZMANumBlockThreads=4` + `LZMAUseSeparateProcess=yes` — parallel lzma2 block compression, with the separate 64-bit compressor process avoiding the 32-bit compiler's memory ceiling.
- **upload_julia**: repack the release tarballs with `pigz` when available (gzip fallback; JuliaCI/rootfs-images#292 adds pigz to the `julia_publish` image), and `7z a -mmt=on` for the Windows zip.
- **Deferred dmg notarization**: `build_dmg.sh` only submits each dmg to Apple when running under `publish.sh`, which waits/staples/promotes them in a final phase — Apple's processing overlaps the remaining triplets instead of blocking each macOS one. Note: `rcodesign notary-wait` exits 0 even for a rejected submission (verified against the pinned 0.29.0 source), so the staple acts as the success gate (a rejected submission has no ticket to staple). Standalone invocation and `PUBLISH_SKIP_NOTARIZATION=1` keep the synchronous path.
- **verify_trusted_commit**: treeless fetches (`--filter=tree:0`) via a promisor remote — the reachability check only walks commit/tag objects. Verified locally against the real repo: the full check runs in ~6s. Servers without filter support ignore the filter, so this degrades gracefully.

Coverage note: the publish-test pipeline exercises everything except the deferred-notarization path (it sets `PUBLISH_SKIP_NOTARIZATION=1`), so that path first runs on a production publish.

Test build running at https://buildkite.com/julialang/julia-publish-test-nosecrets/builds/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)