### PR TITLE
Backport srcdist SIGPIPE fix to `release-1.13`

### DIFF
--- a/utilities/publish_srcdist.sh
+++ b/utilities/publish_srcdist.sh
@@ -63,7 +63,10 @@ for SUFFIX in "" "-full"; do
 
     # The in-tarball prefix is part of the published interface: releases
     # extract to julia-<version>/ (source_dist.yml pins JULIA_COMMIT).
-    FIRST_ENTRY="$(tar -tzf "${FINAL}" | head -1)"
+    # head closing the pipe SIGPIPEs tar (silent exit 141 under pipefail);
+    # mask tar's status -- a bad tarball yields an empty/garbage FIRST_ENTRY
+    # that the prefix check below rejects.
+    FIRST_ENTRY="$( (tar -tzf "${FINAL}" || true) | head -1)"
     if [[ "${FIRST_ENTRY}" != "julia-${JULIA_VERSION}/"* ]]; then
         echo "ERROR: ${FINAL} does not extract to julia-${JULIA_VERSION}/ (first entry: ${FIRST_ENTRY})" >&2
         exit 1


### PR DESCRIPTION
Backport of the third commit on #597: `tar -tzf | head -1` dies of SIGPIPE under pipefail (silently, exit 141), which killed the first srcdist-only publish attempt ([julia-publish build 147](https://buildkite.com/julialang/julia-publish/builds/147)) right after the staged download with nothing in the log.

Needed for the v1.13.0-rc2 source-dist backfill. The staged tarballs from julia-ci build 269 persist, so after this merges only a new julia-publish build is needed (no julia-ci re-run).

- [ ] #597