### PR TITLE
publish-test: compile unsigned Windows installer

### DIFF
--- a/utilities/upload_julia.sh
+++ b/utilities/upload_julia.sh
@@ -196,14 +196,24 @@ elif [[ "${OS}" == "windows" || "${OS}" == "windowsnogpl" ]]; then
     CODESIGN_HOOK_DONE_WIN="Z:${CODESIGN_HOOK_DONE//\//\\}"
     export CODESIGN_HOOK_DONE_WIN
 
+    # Inno Setup validates that every configured SignTool invocation actually
+    # leaves a digital signature.  For the non-production test path, omit the
+    # SignTool entirely instead of pointing it at codesign.sh's no-op mode.
+    iscc_sign_args=()
+    if [[ "${PUBLISH_SKIP_WINDOWS_SIGN:-0}" != "1" ]]; then
+        iscc_sign_args=(
+            /Dsign=true
+            "/Smysigntool=cmd.exe /c $("${WINE}" winepath -w "${THIS_DIR}/windows/wine_signtool.cmd") \$f"
+        )
+    fi
+
     "${WINE}" "${ISCC_EXE}" \
         /DAppVersion="${JULIA_VERSION}" \
         /DSourceDir="$("${WINE}" winepath -w "$(pwd)/${JULIA_INSTALL_DIR}")" \
         /DRepoDir="$("${WINE}" winepath -w "$(pwd)")" \
         /F"${UPLOAD_FILENAME}" \
         /O"$("${WINE}" winepath -w "$(pwd)")" \
-        /Dsign=true \
-        /Smysigntool="cmd.exe /c $("${WINE}" winepath -w "${THIS_DIR}/windows/wine_signtool.cmd") \$f" \
+        "${iscc_sign_args[@]}" \
         "$("${WINE}" winepath -w "${iss_file}")"
 
     # Tripwire: if the Wine->host signing bridge failed silently, the

--- a/utilities/windows/build-installer.iss
+++ b/utilities/windows/build-installer.iss
@@ -104,7 +104,11 @@ Name: "addtopath"; Description: "Add {#AppName} to PATH"; GroupDescription: "{cm
 
 [Files]
 Source: "{#SourceDir}\*"; Excludes: "{#AppMainExeName}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs;
+#ifdef Sign
 Source: "{#SourceDir}\{#AppMainExeName}"; DestDir: "{app}\bin"; Flags: ignoreversion sign;
+#else
+Source: "{#SourceDir}\{#AppMainExeName}"; DestDir: "{app}\bin"; Flags: ignoreversion;
+#endif
 
 
 [Icons]


### PR DESCRIPTION
The non-production publish test has no Azure Trusted Signing equivalent, so its signer intentionally returns success without modifying files. Inno Setup independently checks that each SignTool invocation produced a digital signature, causing the no-GPL dry run to fail while building the embedded uninstaller.

When PUBLISH_SKIP_WINDOWS_SIGN=1, omit both the Inno SignTool configuration and the per-file sign flag. Production publishing continues to configure and verify Authenticode signing unchanged.