### PR TITLE
Backport release source dists (#593 + follow-up fixes) to `release-1.12`

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -128,6 +128,15 @@ and which carry AWS session tags (`step_key`, `build_commit`, `pipeline_slug`, .
   that publish would consume. Build / PR jobs cannot touch release paths
   or sign anything. (Consumers, e.g. juliaup, map PR number → head sha
   via the GitHub API and fetch from the sha path in the `-pr` bucket.)
+  Staged names are always commit-keyed (`julia-<sha10>-<os>-<arch>`);
+  version names exist only at the final promote. A `v*` **tag** build is
+  an *independent* build of its commit that stages under an extra `tag/`
+  path flavor (`bin/<sha>/tag/…`): tag state is baked into build content
+  (`Base.VERSION` on prereleases, the install prefix), so pushing a
+  release branch and its tag — one build each, same commit — must not
+  let the branch build's artifacts stand in for the release. The
+  publish run picks the flavor (and its `TAR_VERSION` naming) from its
+  trigger's branch, which carries the tag name for tag builds.
 * **Tokens**: only `julia-ci` has a tokens role (`julia-oidc-tokens-ci`,
   SSM `ssm:GetParameter` on the telemetry tokens). There is deliberately
   no `-pr` counterpart: a pull request executes attacker-controlled code
@@ -139,6 +148,17 @@ and which carry AWS session tags (`step_key`, `build_commit`, `pipeline_slug`, .
   uploads of already-existing objects fail. The only exception is the
   `julia-latest-*` pointer objects, which release builds intentionally
   repoint. Object versioning on the bucket is recommended belt-and-braces.
+  Write-once is per *commit*, not per build: every object carries a
+  `build-commit` metadata stamp (the Buildkite-attested commit), and
+  `upload_to_s3.sh` treats an existing object from the same commit as
+  success (first upload wins). Builds are not byte-reproducible, so this
+  is what lets a rebuild of an already-staged commit, concurrent sibling
+  builds of the same commit sharing a key (the doctest htmldocs archive
+  during a release-branch + tag double build), and a re-run publish all
+  succeed idempotently instead of going red. A conflict across
+  *different* commits (e.g. a repointed release tag at the final
+  locations) is still a hard error; replacing published artifacts is a
+  deliberate manual operation.
 * Signing never exposes key material: every signature (macOS code signature,
   notarization JWT, GPG tarball signature, docs-deploy SSH authentication)
   is a `kms:Sign` call, conditioned on the calling job's step
@@ -320,9 +340,19 @@ The single publish step signs and packages for every OS on linux:
   Only the notary key uses KMS `EXTERNAL` (BYOK) import, because Apple
   generates App Store Connect API keys and we cannot register our own
   public key with Apple.
-* Retried upload jobs hitting an existing identical object are handled in
-  `utilities/upload_julia.sh` (412 + ETag comparison), not by allowing
-  overwrites.
+* Retried upload jobs hitting an existing object are handled in
+  `utilities/upload_to_s3.sh` (412, then ETag comparison for identical
+  content and the `build-commit` metadata stamp for a sibling build of
+  the same commit), not by allowing overwrites.
+* Re-running a release: use **Rebuild** on the `julia-ci` tag build, or
+  create a new `julia-ci` build with the branch set to the tag name
+  (`v<version>`) — both enter the release tag flow. To re-run just the
+  promote, POST a `julia-publish` build with the release commit and
+  `branch: v<version>` plus `ignore_pipeline_branch_filters: true`
+  (branch webhook builds are disabled on the publish pipeline); a plain
+  `branch: master` build of the same commit would promote it under
+  commit-hash (nightly) names instead. Already-promoted objects are
+  skipped via the same-commit rule above.
 * juliaup needs a change to consume PR binaries: resolve PR number → head
   sha via the GitHub API, then fetch
   `s3://julialang-ephemeral-pr/bin/<sha>/julia-*` (this replaces the old

--- a/ops/README.md
+++ b/ops/README.md
@@ -64,6 +64,12 @@ publish trigger, exactly like `julia-pr`.
    (TRUSTED: role julia-oidc-publish, kms:Sign + read julia-ci staging bucket
     ONLY + write final)
    verify_trusted_commit.sh → sign (rcodesign / Trusted Signing / KMS-GPG) → promote → deploy docs
+
+ For release (v*) tag builds, julia-ci additionally builds the light/full
+ source dists (misc/source_dist.yml) and stages them alongside the
+ binaries; publish_srcdist.sh KMS-signs them and publishes to
+ bin/src/<majmin>/ in the nightlies bucket, and julia-promote copies them
+ to the release bucket and includes them in the checksums files.
 ```
 
 Why this is safe where branch-pinning was not: Buildkite reports a pull

--- a/pipelines/main/misc/deploy_docs.yml
+++ b/pipelines/main/misc/deploy_docs.yml
@@ -47,7 +47,14 @@ steps:
           # S3 grant (and no bucket-listing) is needed here. We still assume the
           # docs-deploy role below for the KMS-backed SSH signing of the push.
           source .buildkite/utilities/aws_oidc.sh docs-deploy
-          aws s3 cp "s3://${STAGING_BUCKET:-julialang-ephemeral-ci}/${S3_BUCKET_PREFIX:-bin}/${BUILDKITE_COMMIT}/julia-htmldocs.tar.gz" .
+          # For a tag-triggered publish (the trigger passes the tag name
+          # through as the branch), read the tag build's docs from the tag/
+          # staging flavor -- the counterpart of the doctest step's upload.
+          STAGING_FLAVOR=""
+          if [[ "$${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+              STAGING_FLAVOR="tag/"
+          fi
+          aws s3 cp "s3://${STAGING_BUCKET:-julialang-ephemeral-ci}/${S3_BUCKET_PREFIX:-bin}/${BUILDKITE_COMMIT}/$${STAGING_FLAVOR}julia-htmldocs.tar.gz" .
 
           echo "--- Configure SSH signing via AWS KMS"
           # The deploy key private half lives in AWS KMS and never leaves

--- a/pipelines/main/misc/doctest.yml
+++ b/pipelines/main/misc/doctest.yml
@@ -67,12 +67,23 @@ steps:
           fi
           source .buildkite/utilities/aws_oidc.sh stage
           source .buildkite/utilities/upload_to_s3.sh
+          # Release (v* tag) builds stage under the tag/ path flavor, like the
+          # binary tarballs: the docs are built by the tagged julia (their
+          # version strings embed its Base.VERSION), so the tag build's docs
+          # must not contend with the release-branch twin build's. Mirrors the
+          # RELEASE_TAG_FLOW predicate in build_envs.sh; misc/deploy_docs.yml
+          # selects the same flavor on download.
+          STAGING_FLAVOR=""
+          if [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == "julia-ci" ]] &&
+             [[ "$${BUILDKITE_TAG:-}" == v[0-9]* || "$${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+              STAGING_FLAVOR="tag/"
+          fi
           # Stage under a stable, version-independent key so the publish
           # pipeline's docs-deploy job can fetch it by exact key (a single
           # public GetObject -- the staging bucket is public-read) rather than
           # listing the bucket, which would need an S3 ListBucket grant.
           UPLOAD_TO_S3_ACL=none upload_to_s3 "doc/$${DOCUMENTER_ARCHIVE}" \
-              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/julia-htmldocs.tar.gz"
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/$${STAGING_FLAVOR}julia-htmldocs.tar.gz"
         env:
           # Give a fake documenter key to get Documenter to try and deploy for us
           DOCUMENTER_KEY: ""

--- a/pipelines/main/misc/source_dist.yml
+++ b/pipelines/main/misc/source_dist.yml
@@ -44,7 +44,10 @@ steps:
           # the tag (a branch build of the tag commit). Release source
           # tarballs have always used the version prefix.
           V="$$(cat VERSION)"
-          make light-source-dist full-source-dist JULIA_COMMIT="$${V}"
+          # FC=gcc satisfies Make.inc's gfortran presence check; the getall
+          # sub-targets only download source tarballs and never run fortran,
+          # and the rootfs has no gfortran.
+          make light-source-dist full-source-dist JULIA_COMMIT="$${V}" FC=gcc
           mv "julia-$${V}_$${V}.tar.gz" "julia-$${V}.tar.gz"
           mv "julia-$${V}_$${V}-full.tar.gz" "julia-$${V}-full.tar.gz"
           sha256sum "julia-$${V}.tar.gz" "julia-$${V}-full.tar.gz"

--- a/pipelines/main/misc/source_dist.yml
+++ b/pipelines/main/misc/source_dist.yml
@@ -1,0 +1,79 @@
+steps:
+  - group: "Check"
+    steps:
+      - label: "source dist"
+        key: source_dist
+        # Release tag flow only (mirrors RELEASE_TAG_FLOW in build_envs.sh):
+        # source dists are published per release, not per commit, and this
+        # step costs a docs build plus a full deps download.
+        if: pipeline.slug == "julia-ci" && (build.tag =~ /^v[0-9]/ || build.branch =~ /^v[0-9]/)
+        depends_on:
+          - "build_x86_64-linux-gnu"
+        plugins:
+          - JuliaCI/external-buildkite#v1:
+              version: "./.buildkite-external-version"
+              repo_url: "https://github.com/JuliaCI/julia-buildkite"
+          - JuliaCI/julia#v1:
+              # Host julia, required by the sandbox plugin; the docs are built
+              # with the freshly-built julia downloaded below.
+              persist_depot_dirs: packages,artifacts,compiled
+              version: '1.11' # GREP_ME: Keep this updated. Do not set it to '1' or 'stable' or 'latest'.
+          - JuliaCI/sandbox#v2:
+              rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v8.5/package_linux.x86_64.tar.gz
+              rootfs_treehash: "8b46765146862479f0a8946f2ef783a8bf93b20f"
+              uid: 1000
+              gid: 1000
+              workspaces:
+                # Include `/cache/repos` so that our `git` version introspection works.
+                - "/cache/repos:/cache/repos"
+        commands: |
+          # Download pre-built julia, extract into `usr/` (the in-tree
+          # build_bindir), so `make -C doc html` finds a julia to run
+          # Documenter with -- no compilation happens in this step.
+          buildkite-agent artifact download --step "build_x86_64-linux-gnu" 'julia-*-linux-x86_64.tar.gz' .
+          mkdir -p ./usr
+          tar -C ./usr --strip-components=1 -zxf julia-*-linux-x86_64.tar.gz
+          rm -f julia-*-linux-x86_64.tar.gz
+
+          echo "--- Build HTML docs (bundled into the source dists)"
+          make --output-sync -C doc html
+
+          echo "--- Build source distribution tarballs"
+          # JULIA_COMMIT is overridden to the version so the in-tarball prefix
+          # is julia-<version>/ even when the agent checkout cannot resolve
+          # the tag (a branch build of the tag commit). Release source
+          # tarballs have always used the version prefix.
+          V="$$(cat VERSION)"
+          make light-source-dist full-source-dist JULIA_COMMIT="$${V}"
+          mv "julia-$${V}_$${V}.tar.gz" "julia-$${V}.tar.gz"
+          mv "julia-$${V}_$${V}-full.tar.gz" "julia-$${V}-full.tar.gz"
+          sha256sum "julia-$${V}.tar.gz" "julia-$${V}-full.tar.gz"
+
+          echo "--- Stage source dists to S3 for the publish pipeline"
+          # Mirror the doctest htmldocs handoff: a write-once upload to this
+          # build's commit-sha-gated staging path via the untrusted `stage`
+          # role, under stable version-independent keys so the publish
+          # pipeline can fetch them by exact key (single public GetObject,
+          # no bucket listing). publish_srcdist.sh reads them back, signs,
+          # and uploads to the canonical locations.
+          if [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == "julia-pr" ]]; then
+              STAGING_BUCKET="julialang-ephemeral-pr"
+          elif [[ "$${BUILDKITE_PIPELINE_SLUG:-}" == julia-buildkite* ]]; then
+              STAGING_BUCKET="julialang-ephemeral-buildkite"
+          else
+              STAGING_BUCKET="julialang-ephemeral-ci"
+          fi
+          source .buildkite/utilities/aws_oidc.sh stage
+          source .buildkite/utilities/upload_to_s3.sh
+          # Always the tag/ staging flavor: the `if:` above restricts this
+          # step to the release tag flow (see STAGING_FLAVOR in build_envs.sh).
+          UPLOAD_TO_S3_ACL=none upload_to_s3 "julia-$${V}.tar.gz" \
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/tag/julia-srcdist.tar.gz"
+          UPLOAD_TO_S3_ACL=none upload_to_s3 "julia-$${V}-full.tar.gz" \
+              "$${STAGING_BUCKET}/$${S3_BUCKET_PREFIX:-bin}/$${BUILDKITE_COMMIT?}/tag/julia-srcdist-full.tar.gz"
+        timeout_in_minutes: 120
+        agents:
+          queue: "test"
+          sandbox_capable: "true"
+          os: "linux"
+          arch: "x86_64"

--- a/pipelines/main/misc/source_dist.yml
+++ b/pipelines/main/misc/source_dist.yml
@@ -44,6 +44,14 @@ steps:
           # the tag (a branch build of the tag commit). Release source
           # tarballs have always used the version prefix.
           V="$$(cat VERSION)"
+          # netlib renamed lapack-<ver>.tgz to .tar.gz (byte-identical) and
+          # the old name 404s; pre-seed the srccache under the name the tree
+          # expects. Best-effort: on failure make tries its own URL as before.
+          LAPACK_VER="$$(sed -n 's/^LAPACK_VER := //p' deps/openblas.version)"
+          mkdir -p deps/srccache
+          curl -fSsL -o "deps/srccache/lapack-$${LAPACK_VER}.tgz" \
+              "https://www.netlib.org/lapack/lapack-$${LAPACK_VER}.tar.gz" \
+              || rm -f "deps/srccache/lapack-$${LAPACK_VER}.tgz"
           # FC=gcc satisfies Make.inc's gfortran presence check; the getall
           # sub-targets only download source tarballs and never run fortran,
           # and the rootfs has no gfortran.

--- a/utilities/build_envs.sh
+++ b/utilities/build_envs.sh
@@ -121,9 +121,58 @@ MAJMIN="$(cut -d. -f1-2 <<<"${JULIA_VERSION}")"
 MAJMINPAT="$(cut -d- -f1 <<<"${JULIA_VERSION}")"
 export JULIA_VERSION MAJMIN MAJMINPAT
 
-# If we're on a tag, then our "tar version" will be the julia version.
-# Otherwise, it's the short commit.
-if git describe --tags --exact-match >/dev/null 2>/dev/null; then
+# Is this job part of the RELEASE flow for a v* tag? True for the tag
+# build itself -- BUILDKITE_TAG is set uniformly on every job of a tag
+# build, and Buildkite reports the tag name as the branch, which also
+# covers a manual re-run created with branch=v<version> -- and for the
+# julia-publish run it triggers (the trigger passes the branch through,
+# pinned to the source build's by the cluster trigger rule). The
+# release-*/master build of the very same commit deliberately does NOT
+# count: the tag build is an independent build, and only ITS artifacts
+# are promoted to the versioned release locations (see STAGING_TARGET
+# below for why the two must not be interchangeable). Restricted to the
+# pipelines that feed releases so that e.g. a julia-pr branch that
+# happens to be named v2-something cannot enter the release flow.
+RELEASE_TAG_FLOW="false"
+case "${BUILDKITE_PIPELINE_SLUG:-}" in
+    julia-ci|julia-publish*)
+        if [[ "${BUILDKITE_TAG:-}" == v[0-9]* || "${BUILDKITE_BRANCH:-}" == v[0-9]* ]]; then
+            RELEASE_TAG_FLOW="true"
+        fi
+        ;;
+esac
+export RELEASE_TAG_FLOW
+
+# The release flow names everything after JULIA_VERSION (the VERSION
+# file), so a tag that disagrees with it would publish artifacts whose
+# names contradict their content. Fail loudly and early instead.
+if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+    RELEASE_TAG="${BUILDKITE_TAG:-${BUILDKITE_BRANCH}}"
+    if [[ "${RELEASE_TAG}" != "v${JULIA_VERSION}" ]]; then
+        echo "ERROR: release tag '${RELEASE_TAG}' does not match the VERSION file ('${JULIA_VERSION}')" >&2
+        exit 1
+    fi
+fi
+
+# TAR_VERSION is the version identity of the artifacts this job handles:
+# the julia version for the release flow, the short commit otherwise.
+if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == julia-publish* ]]; then
+    # Publish naming follows the TRIGGER identity, never checkout state:
+    # whether this checkout happens to contain any given tag depends on
+    # what the agent fetched, and `git describe` here could pick up a tag
+    # that landed only after the triggering branch build (or miss the tag
+    # of a tag-triggered publish) -- either way promoting under names that
+    # do not match the staged artifacts' content.
+    if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+        TAR_VERSION="${JULIA_VERSION}"
+    else
+        TAR_VERSION="${SHORT_COMMIT}"
+    fi
+elif git describe --tags --exact-match >/dev/null 2>/dev/null; then
+    # Build pipelines must agree with what `make` produces from the same
+    # checkout (Make.inc derives the julia-$(JULIA_COMMIT) install prefix
+    # and the binary-dist name from the same `git describe`), so here the
+    # checkout state IS the right source.
     TAR_VERSION="${JULIA_VERSION}"
 else
     TAR_VERSION="${SHORT_COMMIT}"
@@ -293,7 +342,27 @@ export STAGING_BUCKET
 # attested value is the one that cannot drift from the IAM condition.
 # The publish trigger and deploy_docs pass BUILDKITE_COMMIT along, so
 # reads agree with what was staged.
-export STAGING_TARGET="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${UPLOAD_FILENAME}"
+#
+# The release (v* tag) flow stages under an additional tag/ path flavor,
+# because the tag build is an INDEPENDENT build of its commit: tag state
+# is baked into build CONTENT, not just names. Base.VERSION keeps the
+# build-number suffix on prereleases unless the tag was visible at build
+# time (base/version.jl: a pre-tag build reports v"1.13.0-rc2.77", the
+# tag build v"1.13.0-rc2"), and Make.inc derives the julia-$(JULIA_COMMIT)
+# install prefix from the same `git describe`. Pushing a release branch
+# and its tag together fires one build for EACH, for the same commit; the
+# flavor keeps the tag build's artifacts -- the only ones fit to become
+# the release -- from contending with (or losing a first-upload-wins race
+# to) the branch build's. The staged FILENAME is commit-keyed in both
+# flavors: version names are claimed only by the final promote
+# (UPLOAD_TARGETS above), so a repointed tag never leaves a stale
+# version-named object behind in staging.
+if [[ "${RELEASE_TAG_FLOW}" == "true" ]]; then
+    STAGING_FLAVOR="tag/"
+else
+    STAGING_FLAVOR=""
+fi
+export STAGING_TARGET="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${STAGING_FLAVOR}julia-${SHORT_COMMIT}-${OS?}-${ARCH?}"
 
 echo "--- Print the full and short commit hashes"
 echo "The full commit is:                      ${LONG_COMMIT}"

--- a/utilities/publish.sh
+++ b/utilities/publish.sh
@@ -74,8 +74,16 @@ for triplet in "${TRIPLETS[@]}"; do
     fi
 done
 
+echo "+++ Publish source dists"
+# shellcheck source=SCRIPTDIR/aws_oidc.sh
+source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE}"
+if ! bash .buildkite/utilities/publish_srcdist.sh; then
+    echo "ERROR: publishing source dists failed" >&2
+    FAILED+=( "srcdist" )
+fi
+
 if [[ "${#FAILED[@]}" -gt 0 ]]; then
-    echo "--- ${#FAILED[@]} triplet(s) failed to publish: ${FAILED[*]}" >&2
+    echo "--- ${#FAILED[@]} item(s) failed to publish: ${FAILED[*]}" >&2
     exit 1
 fi
 

--- a/utilities/publish_srcdist.sh
+++ b/utilities/publish_srcdist.sh
@@ -63,7 +63,10 @@ for SUFFIX in "" "-full"; do
 
     # The in-tarball prefix is part of the published interface: releases
     # extract to julia-<version>/ (source_dist.yml pins JULIA_COMMIT).
-    FIRST_ENTRY="$(tar -tzf "${FINAL}" | head -1)"
+    # head closing the pipe SIGPIPEs tar (silent exit 141 under pipefail);
+    # mask tar's status -- a bad tarball yields an empty/garbage FIRST_ENTRY
+    # that the prefix check below rejects.
+    FIRST_ENTRY="$( (tar -tzf "${FINAL}" || true) | head -1)"
     if [[ "${FIRST_ENTRY}" != "julia-${JULIA_VERSION}/"* ]]; then
         echo "ERROR: ${FINAL} does not extract to julia-${JULIA_VERSION}/ (first entry: ${FIRST_ENTRY})" >&2
         exit 1

--- a/utilities/publish_srcdist.sh
+++ b/utilities/publish_srcdist.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Sign and publish the source distribution tarballs (release tag flow only).
+#
+# The build pipeline's source_dist step staged the light and full source
+# dists under this commit's tag/ staging path. Download them, GPG-sign via
+# KMS (same key and mechanism as the binary tarballs, see upload_julia.sh),
+# and upload to bin/src/<majmin>/ in the nightlies bucket. julia-promote
+# then copies them to the release bucket alongside the binaries.
+#
+# Invoked by publish.sh after the per-triplet loop, with the publish role
+# already assumed. Standalone invocation also works (it re-establishes the
+# guard + role itself, like upload_julia.sh).
+set -euo pipefail
+
+# build_envs.sh derives per-platform variables from TRIPLET; the source
+# dists are platform-independent, so pin any valid triplet -- only the
+# version / flow / bucket variables are used here.
+export TRIPLET="${TRIPLET:-x86_64-linux-gnu}"
+# shellcheck source=SCRIPTDIR/build_envs.sh
+source .buildkite/utilities/build_envs.sh
+# shellcheck source=SCRIPTDIR/upload_to_s3.sh
+source .buildkite/utilities/upload_to_s3.sh
+
+if [[ "${RELEASE_TAG_FLOW}" != "true" ]]; then
+    echo "Not a release tag build; no source dists to publish."
+    exit 0
+fi
+
+if [[ -z "${PUBLISH_PREAUTHED:-}" ]]; then
+    echo "--- Verify this is a trusted release commit"
+    bash .buildkite/utilities/verify_trusted_commit.sh
+    # shellcheck source=SCRIPTDIR/aws_oidc.sh
+    source .buildkite/utilities/aws_oidc.sh "${PUBLISH_OIDC_MODE:-publish}"
+fi
+
+# Same KMS key / pubkey selection as upload_julia.sh (the non-production
+# publish test stack overrides these).
+TARBALL_SIGNING_KMS_KEY="${TARBALL_SIGNING_KMS_KEY:-alias/julia-tarball-signing}"
+TARBALL_SIGNING_PUBKEY="${TARBALL_SIGNING_PUBKEY-.buildkite/signing-pubkeys/tarball_signing.pub.asc}"
+if [[ -n "${TARBALL_SIGNING_PUBKEY}" ]]; then
+    GPG_PUBKEY_ARGS=( --public-key "${TARBALL_SIGNING_PUBKEY}" )
+else
+    GPG_PUBKEY_ARGS=( --public-key-from-kms )
+    [[ -n "${TARBALL_SIGNING_PUBKEY_CREATED:-}" ]] && GPG_PUBKEY_ARGS+=( --created "${TARBALL_SIGNING_PUBKEY_CREATED}" )
+fi
+
+STAGING_PREFIX="${STAGING_BUCKET}/${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT?}/${STAGING_FLAVOR}"
+
+# Tag builds from before the source_dist step exist(ed) have nothing
+# staged; a re-publish of such a tag must not fail on that.
+if ! aws s3api head-object --bucket "${STAGING_BUCKET}" \
+        --key "${S3_BUCKET_PREFIX}/${BUILDKITE_COMMIT}/${STAGING_FLAVOR}julia-srcdist.tar.gz" >/dev/null 2>&1; then
+    echo "WARN: no staged source dists at s3://${STAGING_PREFIX}julia-srcdist.tar.gz; skipping." >&2
+    exit 0
+fi
+
+for SUFFIX in "" "-full"; do
+    STAGED="julia-srcdist${SUFFIX}.tar.gz"
+    FINAL="julia-${JULIA_VERSION}${SUFFIX}.tar.gz"
+
+    echo "--- Download staged ${STAGED} from s3://${STAGING_PREFIX}${STAGED}"
+    aws s3 cp --only-show-errors "s3://${STAGING_PREFIX}${STAGED}" "${FINAL}"
+
+    # The in-tarball prefix is part of the published interface: releases
+    # extract to julia-<version>/ (source_dist.yml pins JULIA_COMMIT).
+    FIRST_ENTRY="$(tar -tzf "${FINAL}" | head -1)"
+    if [[ "${FIRST_ENTRY}" != "julia-${JULIA_VERSION}/"* ]]; then
+        echo "ERROR: ${FINAL} does not extract to julia-${JULIA_VERSION}/ (first entry: ${FIRST_ENTRY})" >&2
+        exit 1
+    fi
+
+    echo "--- GPG-sign ${FINAL}"
+    python3 .buildkite/utilities/kms_gpg_sign.py \
+        "${GPG_PUBKEY_ARGS[@]}" \
+        --kms-key-id "${TARBALL_SIGNING_KMS_KEY}" \
+        "${FINAL}"
+
+    echo "--- Upload ${FINAL} to s3://${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/"
+    upload_to_s3 "${FINAL}" "${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/${FINAL}"
+    upload_to_s3 "${FINAL}.asc" "${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/${FINAL}.asc"
+done
+
+echo "+++ Published source dists"
+for SUFFIX in "" "-full"; do
+    echo " -> s3://${S3_BUCKET}/${S3_BUCKET_PREFIX}/src/${MAJMIN}/julia-${JULIA_VERSION}${SUFFIX}.tar.gz"
+done

--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -344,6 +344,7 @@ OMITTED_POWERPC = [
 CHECK_STATIC = [
     "analyzegc.yml",
     "doctest.yml",
+    "source_dist.yml",
     "pdf_docs/build_pdf_docs.yml",
     "embedding.yml",
     "trimming.yml",

--- a/utilities/upload_to_s3.sh
+++ b/utilities/upload_to_s3.sh
@@ -15,13 +15,15 @@
 # from OIDC web identity (AWS_WEB_IDENTITY_TOKEN_FILE / AWS_ROLE_ARN).
 export AWS_EC2_METADATA_DISABLED=true
 
-# Upload a local file to `s3://${BUCKET}/${KEY}`, write-once.
+# Upload a local file to `s3://${BUCKET}/${KEY}`, write-once per commit.
 #
 # IAM denies unconditional puts, so a build can never overwrite an existing
 # object (S3 conditional write, If-None-Match: *). If the object already
-# exists (e.g. a retried job) we accept it iff its content matches what we
-# have locally. `julia-latest-*` pointer objects are intentionally
-# overwritten (and only the publish role is allowed to do so).
+# exists we accept it iff its content matches what we have locally (a
+# retried job re-uploading the same bytes), OR iff it was uploaded by
+# another build of the same commit (see below). `julia-latest-*` pointer
+# objects are intentionally overwritten (and only the publish role is
+# allowed to do so).
 upload_to_s3() {
     local file="$1" target="$2"
     local bucket="${target%%/*}"
@@ -32,6 +34,16 @@ upload_to_s3() {
         acl_args=()
     fi
 
+    # Stamp every object with the commit that produced it. BUILDKITE_COMMIT
+    # is the same Buildkite-attested value that gates the staging paths and
+    # that verify_trusted_commit.sh checks before a publish, so the stamp is
+    # trustworthy provenance -- and it is what lets a second build of the
+    # SAME commit be treated as idempotent below.
+    local metadata_args=()
+    if [[ "${BUILDKITE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]]; then
+        metadata_args=( --metadata "build-commit=${BUILDKITE_COMMIT}" )
+    fi
+
     # Debug/test stacks (UPLOAD_TO_S3_OVERWRITE=1) re-publish the same commit
     # repeatedly, so they overwrite unconditionally. This can only ever succeed
     # against a bucket whose role permits an unconditional PutObject -- the
@@ -40,7 +52,8 @@ upload_to_s3() {
     if [[ "${UPLOAD_TO_S3_OVERWRITE:-0}" == "1" || "$(basename "${key}")" == julia-latest-* ]]; then
         aws s3api put-object \
             --bucket "${bucket}" --key "${key}" \
-            --body "${file}" ${acl_args[@]+"${acl_args[@]}"} >/dev/null
+            --body "${file}" ${acl_args[@]+"${acl_args[@]}"} \
+            ${metadata_args[@]+"${metadata_args[@]}"} >/dev/null
         echo "uploaded (overwrite): s3://${target}"
         return 0
     fi
@@ -49,21 +62,46 @@ upload_to_s3() {
     if output="$(aws s3api put-object \
             --bucket "${bucket}" --key "${key}" \
             --body "${file}" ${acl_args[@]+"${acl_args[@]}"} \
+            ${metadata_args[@]+"${metadata_args[@]}"} \
             --if-none-match '*' 2>&1)"; then
         echo "uploaded (write-once): s3://${target}"
         return 0
     fi
 
     if [[ "${output}" == *"PreconditionFailed"* || "${output}" == *"412"* ]]; then
-        local local_md5 remote_etag
+        local remote_info local_md5 remote_etag remote_commit
         local_md5="$(openssl dgst -md5 -r "${file}" | cut -d' ' -f1)"
-        remote_etag="$(aws s3api head-object --bucket "${bucket}" --key "${key}" \
-            --query ETag --output text | tr -d '"')"
+        remote_info="$(aws s3api head-object --bucket "${bucket}" --key "${key}" \
+            --query '[ETag, Metadata."build-commit"]' --output text)"
+        remote_etag="$(cut -f1 <<<"${remote_info}" | tr -d '"')"
+        remote_commit="$(cut -f2 <<<"${remote_info}")"
+        # `--output text` renders a missing metadata entry as literal "None"
+        [[ "${remote_commit}" == "None" ]] && remote_commit=""
         if [[ "${local_md5}" == "${remote_etag}" ]]; then
             echo "already exists with identical content, skipping: s3://${target}"
             return 0
         fi
-        echo "ERROR: s3://${target} already exists with DIFFERENT content; refusing to overwrite" >&2
+        # Julia builds are not byte-reproducible, so two builds of the same
+        # commit legitimately produce different bytes for the same object.
+        # That happens in normal operation: a rebuild of a commit whose
+        # artifacts are already staged, a build that shares a staging key
+        # with a concurrent sibling of the same commit (the doctest
+        # htmldocs archive during a release-branch + tag double build), or
+        # a re-run publish re-signing artifacts whose predecessors were
+        # already promoted. Every writer of a given location is equally
+        # trusted for a given commit -- staging paths are IAM-gated to the
+        # attested build commit, and the final locations are writable only by
+        # the publish role after the trusted-commit check -- so if the
+        # existing object came from this same commit, keep it and succeed:
+        # first upload wins. Anything else (in particular a repointed release
+        # tag, where a version name suddenly maps to a different commit)
+        # stays a hard error: replacing a published object is a deliberate
+        # manual operation.
+        if [[ "${BUILDKITE_COMMIT:-}" =~ ^[0-9a-f]{40}$ && "${remote_commit}" == "${BUILDKITE_COMMIT}" ]]; then
+            echo "already uploaded by another build of commit ${BUILDKITE_COMMIT:0:10}, keeping the existing object: s3://${target}"
+            return 0
+        fi
+        echo "ERROR: s3://${target} already exists with DIFFERENT content (from build-commit: ${remote_commit:-unknown}); refusing to overwrite" >&2
         return 1
     fi
 


### PR DESCRIPTION
Backports the source-dist pipeline work to `release-1.12`, mirroring what `release-1.13` already received (#596, #598, #599, #602):

- #593 — build, sign, and promote release source dists (the `release-1.13`-adapted version, without the `promote_release.sh` hunk that lives on `main`)
- #598 — pass `FC=gcc` to the source dist build
- #599 — pre-seed the renamed netlib lapack tarball
- #602 — fix silent SIGPIPE death in the srcdist prefix check

Stacked on #594 (backport of #586), since `publish_srcdist.sh`/`source_dist.yml` use `RELEASE_TAG_FLOW`/`STAGING_FLAVOR` from `build_envs.sh` introduced there. Merge #594 first (this PR then shrinks to the four srcdist commits), or merge this one directly to take both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)