### PR TITLE
publish: hand off release tags to a gated julia-promote build

### DIFF
--- a/pipelines/promote/0_webui.yml
+++ b/pipelines/promote/0_webui.yml
@@ -4,9 +4,15 @@
 #
 # julia-promote copies a published release from the nightlies bucket to
 # the release bucket (the "bucket dance", see utilities/promote_release.sh).
-# Builds are created MANUALLY by the release manager: New Build with
-# branch = v<version> (and commit left as HEAD, which resolves to the
-# tag), after the julia-publish run for that tag has completed.
+# Builds are created two ways:
+#   * by the trigger step at the end of julia-publish for v* tags; these
+#     arrive paused on a block step (see launch.yml) and promote only when
+#     the release manager clicks "Promote" -- the normal path, and
+#   * MANUALLY: New Build with branch = v<version> (and commit left as
+#     HEAD, which resolves to the tag) -- for backfills and older tags;
+#     these skip the block step, creating the build IS the decision.
+# Either way, unblocking/creating requires build permission on this
+# pipeline, so the set of people who can promote is unchanged.
 #
 # SECURITY: like julia-publish, the pipeline slug is what the
 # julia-oidc-promote IAM role trusts. It MUST be configured in Buildkite

--- a/pipelines/promote/launch.yml
+++ b/pipelines/promote/launch.yml
@@ -6,6 +6,18 @@
 steps:
   - group: "Promote"
     steps:
+      # Builds created by the trigger at the end of julia-publish arrive
+      # blocked here; the release act stays with the release manager, as a
+      # one-click unblock on this build instead of a hand-created New
+      # Build. A block step is an implicit barrier for the steps after it,
+      # so no depends_on is needed -- and none is wanted: on manually
+      # created builds (backfills, older tags) the `if` excludes this step
+      # and promote_all must not reference its key.
+      - block: ":package: Promote ${BUILDKITE_BRANCH}?"
+        key: "promote_gate"
+        prompt: "Copy the published ${BUILDKITE_BRANCH} binaries from the nightlies bucket to julialang-s3, write the checksum files, repoint the majmin-latest pointer, and purge the CDN."
+        if: build.source == "trigger_job"
+
       - label: ":package: promote release"
         key: "promote_all"
         # One promotion at a time: concurrent runs would race on the

--- a/pipelines/publish/launch.yml
+++ b/pipelines/publish/launch.yml
@@ -89,3 +89,21 @@ steps:
           queue: "default"
           os: "linux"
           arch: "x86_64"
+
+  - wait: ~
+
+  # Release tags hand off to julia-promote, where a block step holds the
+  # build until the release manager clicks "Promote" (see
+  # pipelines/promote/launch.yml). Master (nightly) and release-* publishes
+  # have nothing to promote, and a no-GPL publish stages a different
+  # artifact set than promote's MAPPINGS expects, so both are excluded.
+  # Trigger-created builds bypass the target's "Trigger builds after
+  # pushing code: OFF" (that setting only governs webhooks) but still pass
+  # its v* branch limiting.
+  - trigger: "julia-promote"
+    label: ":package: trigger promote (gated)"
+    if: build.branch =~ /^v[0-9]/ && build.env("PUBLISH_NOGPL") != "true"
+    build:
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      message: "promote ${BUILDKITE_BRANCH}"

--- a/utilities/promote_release.sh
+++ b/utilities/promote_release.sh
@@ -5,10 +5,11 @@
 # versions.json, juliaup, setup-julia and the website point.
 #
 # Runs as the single trusted step of the julia-promote pipeline. Builds
-# are created MANUALLY (New Build with branch = v<version>) after the
-# julia-publish run for that tag has completed; the version identity is
-# taken from the branch, never from checkout state, mirroring the publish
-# flow's naming (see TAR_VERSION in build_envs.sh).
+# are created by the tag-guarded trigger at the end of julia-publish
+# (held on a block step until the release manager approves), or MANUALLY
+# (New Build with branch = v<version>) for backfills; the version
+# identity is taken from the branch, never from checkout state, mirroring
+# the publish flow's naming (see TAR_VERSION in build_envs.sh).
 #
 # The release bucket keeps the historical buildbot-era layout (folder
 # x86_64->x64, i686->x86; short mac64/win64 file names), which is what


### PR DESCRIPTION
Promoting a release is currently fully manual: after a tag's julia-publish run passes, the release manager creates a New Build on julia-promote with branch = `v<version>` by hand. The tag was already the deliberate release decision, so this mechanizes the handoff while keeping the final go/no-go with a human — the release act becomes a one-click unblock on an already-verified build instead of hand-assembling one.

**julia-publish side** (`pipelines/publish/launch.yml`): a `wait` + `trigger` step at the end — the same idiom as the julia-ci → julia-publish trigger emitted by `render_launch_pipeline.py` — creates the julia-promote build for the tag:

- Guarded by `build.branch =~ /^v[0-9]/` (the tag-detection pattern already used in `source_dist.yml`), so `master` (nightlies) and `release-*` publishes never trigger a promote.
- Also guarded by `build.env("PUBLISH_NOGPL") != "true"` — a no-GPL publish stages a different artifact set than promote's `MAPPINGS` expects.
- Trigger-created builds bypass the target pipeline's "Trigger builds after pushing code: OFF" (that setting only governs webhooks) but still pass its `v*` branch limiting, so **no webUI settings change is needed** on julia-promote.

**julia-promote side** (`pipelines/promote/launch.yml`): a `block` step in front of `promote_all`. Triggered builds arrive paused on a "Promote v\<version\>?" button; the bucket dance only runs when the release manager clicks it. Unblocking requires build permission on the pipeline — exactly the set of people who can create the manual build today, so no new principals can promote. The `julia-oidc-promote` IAM trust (pipeline UUID + step keys) is unaffected by how the build was created.

Two deliberate details:

- The block carries `if: build.source == "trigger_job"`, so **manually created builds (backfills, older tags) skip the gate** and run immediately as today — creating one by hand already is the decision. This preserves the flow used for the rc2 srcdist backfill.
- `promote_all` gets **no `depends_on`** on the gate: a block step is an implicit barrier for subsequent steps, and on manual builds the gate step is excluded by its `if`, so a `depends_on: promote_gate` would reference a nonexistent key.

Abandoned tags fail no one: if an rc turns out bad, the blocked build just sits unclicked (or gets cancelled) and the next rc supersedes it.

**Deployment**: the promote side tracks julia-buildkite `main` and is live on merge, which is safe on its own (it only affects builds that don't exist yet, and only trigger-created ones). The publish side loads via the julia checkout's `.buildkite-external-version` pin, so tags only exercise the trigger once their release branch's pin includes this — e.g. 1.13 tags need the pin bump backported to `release-1.13`. Until then everything stays on the manual path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)