### PR TITLE
coverage: use a single Codecov flag per upload

### DIFF
--- a/pipelines/scheduled/coverage/upload_coverage.jl
+++ b/pipelines/scheduled/coverage/upload_coverage.jl
@@ -268,7 +268,7 @@ function upload_coverage(fcs)
 
     # Determine job characteristics for parallel uploads
     platform = Sys.islinux() ? "linux" : Sys.isapple() ? "macos" : "windows"
-    job_flags = [platform, "coverage"]
+    job_flags = [platform]
 
     # Use build number to group parallel uploads
     build_id = get(ENV, "BUILDKITE_BUILD_NUMBER", nothing)


### PR DESCRIPTION
Codecov warns "Multiple flags detected. Please ensure one flag per upload." on commits from the scheduled coverage pipeline, because each platform uploaded with two flags (e.g. linux,coverage). The extra "coverage" flag distinguishes nothing, and multi-flag uploads break Codecov's flag analytics/carryforward attribution. Upload with just the platform flag instead. This also shortens the Coveralls job_flag from e.g. linux-coverage to linux.