### PR TITLE
Mount git mirrors into the linux coverage sandbox

### DIFF
--- a/pipelines/scheduled/coverage/coverage.yml
+++ b/pipelines/scheduled/coverage/coverage.yml
@@ -24,6 +24,8 @@ steps:
               rootfs_treehash: "8b46765146862479f0a8946f2ef783a8bf93b20f"
               uid: 1000
               gid: 1000
+              workspaces:
+                - "/cache/repos:/cache/repos"
         timeout_in_minutes: 720 # 12h
         commands: |
           echo "--- Obtain coverage tokens"


### PR DESCRIPTION
The checkout borrows its entire object database from the agent's git mirror via .git/objects/info/alternates, so any git command that reads objects (git log, git describe) fails inside the nested sandbox unless /cache/repos is mapped in. Every other sandboxed step already carries this workspace; coverage.yml was the one omission, degrading the build stamp to 1.14.0-DEV.unknown and stripping commit metadata from the Coveralls upload.