### PR TITLE
Fix scheduled coverage upload failures

### DIFF
--- a/pipelines/scheduled/coverage/coverage.yml
+++ b/pipelines/scheduled/coverage/coverage.yml
@@ -38,8 +38,10 @@ steps:
             echo "No coverage tokens in this pipeline; coverage uploads will be skipped"
           else
             source .buildkite/utilities/aws_oidc.sh tokens
-            export CODECOV_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text)"
-            export COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)"
+            CODECOV_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text)" || { echo "Failed to fetch Codecov token" >&2; exit 1; }
+            COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)" || { echo "Failed to fetch Coveralls token" >&2; exit 1; }
+            export CODECOV_TOKEN COVERALLS_TOKEN
+            [[ -n "$${CODECOV_TOKEN}" && -n "$${COVERALLS_TOKEN}" ]] || { echo "Coverage token fetch returned an empty value" >&2; exit 1; }
           fi
 
           echo "--- Build Julia from source"
@@ -68,7 +70,7 @@ steps:
           buildkite-agent artifact upload lcov_files.tar.gz
 
           echo "--- Process and upload coverage information"
-          if [[ -n "$${CODECOV_TOKEN:-}" ]]; then
+          if [[ -n "$${CODECOV_TOKEN:-}" && -n "$${COVERALLS_TOKEN:-}" ]]; then
             ./julia --color=yes .buildkite/pipelines/scheduled/coverage/upload_coverage.jl
           else
             echo "No coverage tokens; skipping upload"
@@ -105,8 +107,10 @@ steps:
             echo "No coverage tokens in this pipeline; coverage uploads will be skipped"
           else
             source .buildkite/utilities/aws_oidc.sh tokens
-            export CODECOV_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text)"
-            export COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)"
+            CODECOV_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text)" || { echo "Failed to fetch Codecov token" >&2; exit 1; }
+            COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)" || { echo "Failed to fetch Coveralls token" >&2; exit 1; }
+            export CODECOV_TOKEN COVERALLS_TOKEN
+            [[ -n "$${CODECOV_TOKEN}" && -n "$${COVERALLS_TOKEN}" ]] || { echo "Coverage token fetch returned an empty value" >&2; exit 1; }
           fi
 
           echo "--- Build Julia from source"
@@ -135,7 +139,7 @@ steps:
           buildkite-agent artifact upload lcov_files.tar.gz
 
           echo "--- Process and upload coverage information"
-          if [[ -n "$${CODECOV_TOKEN:-}" ]]; then
+          if [[ -n "$${CODECOV_TOKEN:-}" && -n "$${COVERALLS_TOKEN:-}" ]]; then
             ./julia --color=yes .buildkite/pipelines/scheduled/coverage/upload_coverage.jl
           else
             echo "No coverage tokens; skipping upload"
@@ -164,12 +168,14 @@ steps:
               always-pull: true
               command: ["bash", "-c", "
                 echo '--- Obtain coverage tokens' &&
-                if [[ $${BUILDKITE_PIPELINE_SLUG} == julia-pr ]]; then
-                  echo 'PR build: no coverage tokens; coverage uploads will be skipped';
+                if [[ $${BUILDKITE_PIPELINE_SLUG} != julia-ci ]]; then
+                  echo 'No coverage tokens in this pipeline; coverage uploads will be skipped';
                 else
                   source .buildkite/utilities/aws_oidc.sh tokens &&
-                  export CODECOV_TOKEN=$$(MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text) &&
-                  export COVERALLS_TOKEN=$$(MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text);
+                  CODECOV_TOKEN=$$(MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 aws ssm get-parameter --with-decryption --name /julia-ci/tokens/codecov_token --query Parameter.Value --output text) &&
+                  COVERALLS_TOKEN=$$(MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text) &&
+                  export CODECOV_TOKEN COVERALLS_TOKEN &&
+                  [[ -n $${CODECOV_TOKEN} && -n $${COVERALLS_TOKEN} ]] || { echo 'Coverage token fetch returned an empty value' >&2; exit 1; };
                 fi &&
                 echo '--- Build Julia from source' &&
                 make -j$${JULIA_NUM_THREADS} VERBOSE=1 &&
@@ -191,10 +197,10 @@ steps:
                 tar -zcf lcov_files.tar.gz lcov_files/ &&
                 buildkite-agent artifact upload lcov_files.tar.gz &&
                 echo '--- Process and upload coverage information' &&
-                if [[ -n $${CODECOV_TOKEN:-} ]]; then
+                if [[ -n $${CODECOV_TOKEN:-} && -n $${COVERALLS_TOKEN:-} ]]; then
                   ./usr/bin/julia.exe --color=yes .buildkite/pipelines/scheduled/coverage/upload_coverage.jl;
                 else
-                  echo 'No coverage tokens (PR build); skipping upload';
+                  echo 'No coverage tokens; skipping upload';
                 fi
                 "]
               propagate-environment: true
@@ -245,16 +251,19 @@ steps:
         timeout_in_minutes: 10
         commands: |
           echo "--- Signal completion of parallel coverage uploads"
-          # PR builds hold no tokens and did not upload anything, so there
-          # is nothing to finalize there.
-          if [[ "$${BUILDKITE_PIPELINE_SLUG}" == "julia-pr" ]]; then
-            echo "PR build: nothing was uploaded; nothing to finalize"
-          else
+          if [[ "$${BUILDKITE_PIPELINE_SLUG}" == "julia-ci" ]]; then
             # The coveralls token is fetched from SSM Parameter Store with
             # this job's OIDC identity; no static secrets exist in CI config.
             source .buildkite/utilities/aws_oidc.sh tokens
-            export COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)"
+            COVERALLS_TOKEN="$$(aws ssm get-parameter --with-decryption --name /julia-ci/tokens/coveralls_token --query Parameter.Value --output text)" || { echo "Failed to fetch Coveralls token" >&2; exit 1; }
+            export COVERALLS_TOKEN
+            [[ -n "$${COVERALLS_TOKEN}" ]] || { echo "Coveralls token fetch returned an empty value" >&2; exit 1; }
+          fi
+
+          if [[ -n "$${COVERALLS_TOKEN:-}" ]]; then
             julia --color=yes .buildkite/pipelines/scheduled/coverage/finish_parallel_coverage.jl
+          else
+            echo "No Coveralls token; nothing to finalize"
           fi
         agents:
           queue: "test"

--- a/pipelines/scheduled/coverage/finish_parallel_coverage.jl
+++ b/pipelines/scheduled/coverage/finish_parallel_coverage.jl
@@ -24,15 +24,13 @@ build_number = get(ENV, "BUILDKITE_BUILD_NUMBER", nothing)
 @info "Finishing parallel Coveralls uploads" build_number=build_number
 
 try
-    success = retry(Coverage.finish_coveralls_parallel, delays=ExponentialBackOff(n=5))(token=coveralls_token, build_num=build_number)
-    if success
-        @info "Successfully signaled parallel job completion to Coveralls"
-        exit(0)
-    else
-        @error "Failed to signal parallel completion"
-        exit(1)
-    end
+    retry(Coverage.finish_coveralls_parallel, delays=ExponentialBackOff(n=5))(
+        token=coveralls_token,
+        build_num=build_number,
+    )
 catch e
     @error "Error during parallel completion" exception=e
     exit(1)
 end
+
+@info "Successfully signaled parallel job completion to Coveralls"

--- a/utilities/aws_oidc.sh
+++ b/utilities/aws_oidc.sh
@@ -144,7 +144,11 @@ buildkite-agent oidc request-token \
     --aws-session-tag "${_OIDC_AWS_SESSION_TAGS}" \
     > "${_OIDC_TOKEN_FILE}"
 
-export AWS_WEB_IDENTITY_TOKEN_FILE="${_OIDC_TOKEN_FILE}"
+AWS_WEB_IDENTITY_TOKEN_FILE="${_OIDC_TOKEN_FILE}"
+if command -v cygpath >/dev/null 2>&1; then
+    AWS_WEB_IDENTITY_TOKEN_FILE="$(cygpath -w "${_OIDC_TOKEN_FILE}")"
+fi
+export AWS_WEB_IDENTITY_TOKEN_FILE
 export AWS_ROLE_ARN="arn:aws:iam::${JULIA_CI_AWS_ACCOUNT_ID}:role/julia-oidc-${_OIDC_ROLE_SUFFIX}"
 AWS_ROLE_SESSION_NAME="bk-$(tr -dc 'a-zA-Z0-9=,.@-' <<<"${BUILDKITE_STEP_KEY:-job}" | cut -c1-48)-${BUILDKITE_BUILD_NUMBER:-0}"
 export AWS_ROLE_SESSION_NAME


### PR DESCRIPTION
## Summary

- convert the Buildkite OIDC token path for the Windows AWS CLI
- fail trusted coverage jobs when token retrieval fails or returns empty values
- gate uploads and finalization on the fetched token variables
- rely on Coverage 1.8.2 throwing so the Coveralls completion retry is effective

## Validation

- parsed `coverage.yml` and syntax-checked all four embedded shell command blocks
- ran `shellcheck utilities/aws_oidc.sh`
- verified the OIDC helper preserves Unix paths and exports a `cygpath -w` path when available
- ran `git diff --check`

Live Windows/coverage-provider validation will follow on the next scheduled build.