### PR TITLE
ci: add scheduled optimized Linux build

### DIFF
--- a/pipelines/main/README.md
+++ b/pipelines/main/README.md
@@ -13,9 +13,11 @@ Builds are split across three Buildkite pipelines by trust level (see
 | `julia-publish` | (triggered by `julia-ci`) signs + promotes        | trusted (KMS signing keys)     |
 
 The daily `julia-ci` schedule runs coverage, a from-source assertion build
-with rr tests, and no-GPL builds for Linux, macOS, and Windows. It does not
-repeat the per-commit groups. The no-GPL artifacts are promoted by a
-`julia-publish` build with `PUBLISH_NOGPL=true`.
+with rr tests, no-GPL builds for Linux, macOS, and Windows, and an x86-64
+Linux PGO+LTO+BOLT build with allow-fail tests. It does not repeat the
+per-commit groups. `julia-publish` promotes the scheduled artifacts; no-GPL
+builds go to `julialang-nogpl`, while optimized builds use
+`julialangnightlies/bin/linuxopt/`.
 
 Coverage also runs on pull requests with the `needs full CI` label, without
 uploading to Codecov or Coveralls.

--- a/pipelines/main/platforms/build_linux.yml
+++ b/pipelines/main/platforms/build_linux.yml
@@ -38,4 +38,5 @@ steps:
           TRIPLET: "${TRIPLET?}"
           MAKE_FLAGS: "${MAKE_FLAGS?}"
           ROOTFS_IMAGE_NAME: "${ROOTFS_IMAGE_NAME?}"
+          JULIA_CI_BUILD_MODE: "${JULIA_CI_BUILD_MODE-}"
           BUILDKITE_CANCEL_SIGNAL: "SIGQUIT"

--- a/pipelines/publish-test/launch.yml
+++ b/pipelines/publish-test/launch.yml
@@ -52,7 +52,7 @@ steps:
           arch: "x86_64"
         env:
           # By default, test the regular Linux + macOS triplets. Setting
-          # PUBLISH_NOGPL=true on the build selects the scheduled no-GPL list.
+          # PUBLISH_SCHEDULED=true on the build selects the scheduled list.
           PUBLISH_ARCHES_FILES: ".buildkite/pipelines/main/platforms/upload_linux.arches .buildkite/pipelines/main/platforms/upload_macos.arches"
           # Assume the throwaway test role (test keys + test bucket only).
           PUBLISH_OIDC_MODE: "publish-test"

--- a/pipelines/publish/launch.yml
+++ b/pipelines/publish/launch.yml
@@ -79,7 +79,7 @@ steps:
       # role-assuming "upload docs" job (see misc/deploy_docs.yml), and a
       # duplicate key across the build is rejected.
       - label: "deploy docs"
-        if: build.env("PUBLISH_NOGPL") != "true"
+        if: build.env("PUBLISH_SCHEDULED") != "true"
         plugins:
           - JuliaCI/external-buildkite#v1:
               version: "./.buildkite-external-version"

--- a/pipelines/scheduled/platforms/build_linux.opt.arches
+++ b/pipelines/scheduled/platforms/build_linux.opt.arches
@@ -1,0 +1,8 @@
+# ROOTFS_IMAGE_NAME    TRIPLET                ARCH      ARCH_ROOTFS    JULIA_CI_BUILD_MODE    MAKE_FLAGS    TIMEOUT    ROOTFS_TAG     ROOTFS_HASH
+llvm_passes            x86_64-linux-gnuopt    x86_64    x86_64         pgo-lto-bolt        .             .          v8.5           630126d5595f428ef824651b9be020ffc485eb6f
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# This builds LLVM twice and Julia three times.
+#default TIMEOUT 360

--- a/pipelines/scheduled/platforms/test_linux.opt.arches
+++ b/pipelines/scheduled/platforms/test_linux.opt.arches
@@ -1,0 +1,8 @@
+# ROOTFS_IMAGE_NAME    TRIPLET                ARCH      ARCH_ROOTFS    TIMEOUT    USE_RR    ROOTFS_TAG     ROOTFS_HASH
+tester_linux           x86_64-linux-gnuopt    x86_64    x86_64         .          .         v8.5           0180f0aba045c63c44e4732b7981716aa77eaf71
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Use the regular Linux test timeout.
+#default TIMEOUT 155

--- a/pipelines/scheduled/platforms/upload_linux.opt.arches
+++ b/pipelines/scheduled/platforms/upload_linux.opt.arches
@@ -1,0 +1,8 @@
+# TRIPLET              TIMEOUT
+x86_64-linux-gnuopt    .
+
+# These special lines allow us to embed default values for the columns above.
+# Any column without a default mapping here will simply substitute a `.` to the empty string
+
+# Uploads should not take much time
+#default TIMEOUT 30

--- a/utilities/build_julia.sh
+++ b/utilities/build_julia.sh
@@ -85,9 +85,37 @@ filter_buildroot() {
     fi
 }
 
-echo "--- Build Julia"
-echo "Note: The log stream is filtered. [buildroot] replaces pwd $(pwd)"
-${MAKE} "${MFLAGS[@]}" 2>&1 | filter_buildroot
+if [[ "${JULIA_CI_BUILD_MODE-}" == "pgo-lto-bolt" ]]; then
+    echo "--- Build Julia (optimized: PGO+LTO+BOLT)"
+    echo "Note: The log stream is filtered. [buildroot] replaces pwd $(pwd)"
+    BOLT_MAKE=( "${MAKE}" -C contrib/pgo-lto-bolt "${MFLAGS[@]}" "STAGE2_BUILD=$(pwd)" )
+
+    # stage1 only collects compiler profiles. Avoid building its sysimage for
+    # every CPU target; stage2 still uses the release target list from MFLAGS.
+    echo "--- [pgo-lto-bolt] make stage1"
+    "${BOLT_MAKE[@]}" "JULIA_CPU_TARGET=generic" stage1 2>&1 | filter_buildroot
+
+    # These must be separate make invocations. FILES_TO_OPTIMIZE is derived
+    # from stage1's library symlinks when each invocation starts.
+    for STAGE in stage2 copy_originals bolt_instrument finish_stage2 merge_data bolt; do
+        echo "--- [pgo-lto-bolt] make ${STAGE}"
+        "${BOLT_MAKE[@]}" "${STAGE}" 2>&1 | filter_buildroot
+    done
+
+    echo "--- [pgo-lto-bolt] Upload profile data to buildkite"
+    buildkite-agent artifact upload "contrib/pgo-lto-bolt/profiles/merged.prof"
+    buildkite-agent artifact upload "contrib/pgo-lto-bolt/profiles-bolt/*.merged.fdata"
+
+    echo "--- [pgo-lto-bolt] Delete pre-BOLT library originals"
+    "${BOLT_MAKE[@]}" delete_originals
+elif [[ -n "${JULIA_CI_BUILD_MODE-}" ]]; then
+    echo "ERROR: unknown JULIA_CI_BUILD_MODE '${JULIA_CI_BUILD_MODE}'" >&2
+    exit 1
+else
+    echo "--- Build Julia"
+    echo "Note: The log stream is filtered. [buildroot] replaces pwd $(pwd)"
+    ${MAKE} "${MFLAGS[@]}" 2>&1 | filter_buildroot
+fi
 
 
 echo "--- Check that the working directory is clean"

--- a/utilities/extract_triplet.sh
+++ b/utilities/extract_triplet.sh
@@ -35,6 +35,9 @@ case "${TRIPLET}" in
     *-gnunogpl) # builds that use `USE_GPL_LIBS=0`
         OS="linuxnogpl"
         ;;
+    *-gnuopt) # optimized Linux builds
+        OS="linuxopt"
+        ;;
     *-musl)
         OS="musl"
         ;;

--- a/utilities/publish.sh
+++ b/utilities/publish.sh
@@ -19,11 +19,12 @@ set -euo pipefail
 
 # The set of arches to publish. Mirrors what the build pipeline staged.
 # Each file's rows define TRIPLET (and TIMEOUT); see utilities/arches_env.sh.
-if [[ "${PUBLISH_NOGPL:-}" == "true" ]]; then
+if [[ "${PUBLISH_SCHEDULED:-}" == "true" ]]; then
     ARCHES_FILES=(
         .buildkite/pipelines/scheduled/platforms/upload_linux.no_gpl.arches
         .buildkite/pipelines/scheduled/platforms/upload_macos.no_gpl.arches
         .buildkite/pipelines/scheduled/platforms/upload_windows.no_gpl.arches
+        .buildkite/pipelines/scheduled/platforms/upload_linux.opt.arches
     )
 elif [[ -n "${PUBLISH_ARCHES_FILES:-}" ]]; then
     # shellcheck disable=SC2206

--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -33,8 +33,8 @@ PowerPC: `launch_powerpc.jl` only uploads powerpc arches for Julia < 1.12. On
 current master (1.14) it is a no-op, so the powerpc arches are intentionally
 omitted (see OMITTED_POWERPC below). This matches the runtime behaviour.
 
-Schedule builds emit the scheduled workload groups and a no-GPL publish
-trigger instead of the per-commit groups.
+Schedule builds emit the scheduled workload groups and publish trigger instead
+of the per-commit groups.
 """
 
 import os
@@ -372,6 +372,12 @@ SCHEDULE_GROUPS = [
         ("build_macos.no_gpl.arches", "build_macos.yml"),
         ("build_windows.no_gpl.arches", "build_windows.yml"),
     ]),
+    ("Optimized Build", "false", [
+        ("build_linux.opt.arches", "build_linux.yml"),
+    ]),
+    ("Optimized Tests (Allow Fail)", "true", [
+        ("test_linux.opt.arches", "test_linux.yml"),
+    ]),
 ]
 
 
@@ -475,9 +481,9 @@ def schedule_group_text(label, arches_list, allow_fail):
     return emit_group(label, "\n".join(c for c in chunks if c))
 
 
-def trailer_text(nogpl=False):
-    suffix = " (no-GPL)" if nogpl else ""
-    message = "publish no-GPL" if nogpl else "publish"
+def trailer_text(scheduled=False):
+    suffix = " (scheduled)" if scheduled else ""
+    message = "publish scheduled" if scheduled else "publish"
     lines = [
         "  - wait: ~",
         '  - trigger: "julia-publish"',
@@ -488,8 +494,8 @@ def trailer_text(nogpl=False):
         '      branch: "${BUILDKITE_BRANCH}"',
         f'      message: "{message}: ${{BUILDKITE_MESSAGE}}"',
     ]
-    if nogpl:
-        lines.extend(("      env:", '        PUBLISH_NOGPL: "true"'))
+    if scheduled:
+        lines.extend(("      env:", '        PUBLISH_SCHEDULED: "true"'))
     return "\n".join(lines)
 
 
@@ -500,7 +506,7 @@ def main():
         sys.stdout.write("steps:\n")
         sys.stdout.write("\n".join(blocks))
         sys.stdout.write("\n")
-        sys.stdout.write(trailer_text(nogpl=True))
+        sys.stdout.write(trailer_text(scheduled=True))
         sys.stdout.write("\n")
         return
 

--- a/utilities/tests/test_render_launch_pipeline.py
+++ b/utilities/tests/test_render_launch_pipeline.py
@@ -30,20 +30,28 @@ class RenderLaunchPipelineTests(unittest.TestCase):
     def test_schedule_mode(self):
         output = render("schedule")
 
-        for group in ("Source Build", "Source Tests (Allow Fail)", "no_GPL"):
+        for group in ("Source Build", "Source Tests (Allow Fail)", "no_GPL",
+                      "Optimized Build", "Optimized Tests (Allow Fail)"):
             self.assertEqual(output.count(f'group: "{group}"'), 1)
         self.assertNotIn('group: "Build"', output)
         self.assertNotIn('group: "Test"', output)
 
-        self.assertEqual(output.count('key: "build_'), 5)
-        self.assertEqual(output.count('key: "test_'), 2)
-        self.assertEqual(output.count("soft_fail: false"), 5)
-        self.assertEqual(output.count("soft_fail: true"), 2)
+        self.assertEqual(output.count('key: "build_'), 6)
+        self.assertEqual(output.count('key: "test_'), 3)
+        self.assertEqual(output.count("soft_fail: false"), 6)
+        self.assertEqual(output.count("soft_fail: true"), 3)
         self.assertEqual(
             output.count('depends_on:\n          - "build_x86_64-linux-gnusrcassert"'),
             2,
         )
-        self.assertIn('PUBLISH_NOGPL: "true"', output)
+        self.assertEqual(
+            output.count('depends_on:\n          - "build_x86_64-linux-gnuopt"'),
+            1,
+        )
+        self.assertEqual(output.count('JULIA_CI_BUILD_MODE: "pgo-lto-bolt"'), 1)
+        self.assertIn('PUBLISH_SCHEDULED: "true"', output)
+        self.assertNotIn("PUBLISH_NOGPL", output)
+        self.assertIn('label: ":rocket: trigger publish (scheduled)"', output)
         self.assertIn('trigger: "julia-publish"', output)
 
     def test_normal_mode_excludes_schedule_groups(self):
@@ -52,7 +60,7 @@ class RenderLaunchPipelineTests(unittest.TestCase):
         for group in ("Build", "Check", "Test", "Allow Fail"):
             self.assertIn(f'group: "{group}"', output)
         self.assertNotIn('group: "Source Build"', output)
-        self.assertNotIn("PUBLISH_NOGPL", output)
+        self.assertNotIn("PUBLISH_SCHEDULED", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Build an x86-64 Linux nightly through Julia's PGO, ThinLTO, and BOLT stages, test it as allow-fail, and publish it under linuxopt. Use a generic stage-1 sysimage to keep profiling affordable while retaining the release CPU targets for stage 2.

Give the build path and scheduled publish explicit selectors. This leaves room for later optimized platforms without colliding with Julia's release/debug build mode or treating the regular-GPL optimized artifact as a no-GPL build.

Closes https://github.com/JuliaCI/julia-buildkite/pull/345
Closes https://github.com/JuliaCI/julia-buildkite/pull/492