### PR TITLE
ci: run scheduled workloads on full-CI PRs

### DIFF
--- a/pipelines/main/README.md
+++ b/pipelines/main/README.md
@@ -17,8 +17,8 @@ with rr tests, and no-GPL builds for Linux, macOS, and Windows. It does not
 repeat the per-commit groups. The no-GPL artifacts are promoted by a
 `julia-publish` build with `PUBLISH_NOGPL=true`.
 
-Coverage also runs on pull requests with the `needs full CI` label, without
-uploading to Codecov or Coveralls.
+Pull requests with the `needs full CI` label also run the scheduled workloads.
+Coverage data is collected but not uploaded to Codecov or Coveralls.
 
 Each build step stages its unsigned tarball directly (write-once, no relay
 jobs) to a commit-sha-gated path in its pipeline's own ephemeral staging

--- a/pipelines/main/launch_coverage.yml
+++ b/pipelines/main/launch_coverage.yml
@@ -21,6 +21,6 @@ steps:
           buildkite-agent pipeline upload .buildkite/pipelines/scheduled/coverage/coverage.yml
 
         agents:
-          queue: "build"
+          queue: "launch"
           os: "linux"
           arch: "x86_64" # prevent from running on PiBots

--- a/pipelines/main/launch_untrusted_builders.yml
+++ b/pipelines/main/launch_untrusted_builders.yml
@@ -59,6 +59,20 @@ steps:
       os: "linux"
       arch: "x86_64" # prevent from running on PiBots
 
+  - label: ":rocket: Launch scheduled workloads"
+    if: build.pull_request.labels includes "needs full CI"
+    plugins:
+      - JuliaCI/external-buildkite#v1:
+          version: "./.buildkite-external-version"
+          repo_url: "https://github.com/JuliaCI/julia-buildkite"
+    commands: |
+      python3 .buildkite/utilities/render_launch_pipeline.py --scheduled-workloads > pipeline.scheduled.generated.yml
+      buildkite-agent pipeline upload pipeline.scheduled.generated.yml
+    agents:
+      queue: "launch"
+      os: "linux"
+      arch: "x86_64"
+
   # The barrier + trigger of the trusted julia-publish pipeline are emitted by
   # render_launch_pipeline.py at the END of the rendered document, in the SAME
   # `pipeline upload` as the Build/Check/Test/Allow-Fail groups. That is on

--- a/pipelines/promote/0_webui.yml
+++ b/pipelines/promote/0_webui.yml
@@ -27,7 +27,7 @@ steps:
     steps:
       - label: "Launch promote"
         agents:
-          queue: "default"
+          queue: "launch"
           os: "linux"
         plugins:
           - JuliaCI/external-buildkite#v1:

--- a/pipelines/publish-test/0_webui.yml
+++ b/pipelines/publish-test/0_webui.yml
@@ -19,7 +19,7 @@ steps:
     steps:
       - label: "Launch publish-test jobs"
         agents:
-          queue: "default"
+          queue: "launch"
           os: "linux"
         plugins:
           - JuliaCI/external-buildkite#v1:

--- a/pipelines/publish/0_webui.yml
+++ b/pipelines/publish/0_webui.yml
@@ -23,7 +23,7 @@ steps:
     steps:
       - label: "Launch publish jobs"
         agents:
-          queue: "default"
+          queue: "launch"
           os: "linux"
         plugins:
           - JuliaCI/external-buildkite#v1:

--- a/pipelines/publish/launch.yml
+++ b/pipelines/publish/launch.yml
@@ -86,6 +86,6 @@ steps:
               repo_url: "https://github.com/JuliaCI/julia-buildkite"
         commands: "buildkite-agent pipeline upload .buildkite/pipelines/main/misc/deploy_docs.yml"
         agents:
-          queue: "default"
+          queue: "launch"
           os: "linux"
           arch: "x86_64"

--- a/utilities/render_launch_pipeline.py
+++ b/utilities/render_launch_pipeline.py
@@ -34,9 +34,11 @@ current master (1.14) it is a no-op, so the powerpc arches are intentionally
 omitted (see OMITTED_POWERPC below). This matches the runtime behaviour.
 
 Schedule builds emit the scheduled workload groups and a no-GPL publish
-trigger instead of the per-commit groups.
+trigger instead of the per-commit groups. Labeled PRs render the same workload
+groups as a supplemental pipeline, without a publish trigger.
 """
 
+import argparse
 import os
 import re
 import subprocess
@@ -493,15 +495,28 @@ def trailer_text(nogpl=False):
     return "\n".join(lines)
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scheduled-workloads",
+        action="store_true",
+        help="render scheduled workloads without the scheduled publish trigger",
+    )
+    return parser.parse_args()
+
+
 def main():
-    if os.environ.get("BUILDKITE_SOURCE") == "schedule":
+    args = parse_args()
+    is_schedule = os.environ.get("BUILDKITE_SOURCE") == "schedule"
+    if is_schedule or args.scheduled_workloads:
         blocks = [schedule_group_text(label, arches, allow_fail)
                   for label, allow_fail, arches in SCHEDULE_GROUPS]
         sys.stdout.write("steps:\n")
         sys.stdout.write("\n".join(blocks))
         sys.stdout.write("\n")
-        sys.stdout.write(trailer_text(nogpl=True))
-        sys.stdout.write("\n")
+        if is_schedule and not args.scheduled_workloads:
+            sys.stdout.write(trailer_text(nogpl=True))
+            sys.stdout.write("\n")
         return
 
     blocks = [

--- a/utilities/tests/test_render_launch_pipeline.py
+++ b/utilities/tests/test_render_launch_pipeline.py
@@ -10,14 +10,14 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 RENDERER = os.path.join(ROOT, "utilities", "render_launch_pipeline.py")
 
 
-def render(source=None):
+def render(*args, source=None):
     env = os.environ.copy()
     if source is None:
         env.pop("BUILDKITE_SOURCE", None)
     else:
         env["BUILDKITE_SOURCE"] = source
     return subprocess.run(
-        [sys.executable, RENDERER],
+        [sys.executable, RENDERER, *args],
         cwd=ROOT,
         env=env,
         check=True,
@@ -28,7 +28,7 @@ def render(source=None):
 
 class RenderLaunchPipelineTests(unittest.TestCase):
     def test_schedule_mode(self):
-        output = render("schedule")
+        output = render(source="schedule")
 
         for group in ("Source Build", "Source Tests (Allow Fail)", "no_GPL"):
             self.assertEqual(output.count(f'group: "{group}"'), 1)
@@ -53,6 +53,21 @@ class RenderLaunchPipelineTests(unittest.TestCase):
             self.assertIn(f'group: "{group}"', output)
         self.assertNotIn('group: "Source Build"', output)
         self.assertNotIn("PUBLISH_NOGPL", output)
+
+    def test_labeled_pr_mode_emits_scheduled_workloads_without_publish(self):
+        output = render("--scheduled-workloads")
+
+        for group in ("Source Build", "Source Tests (Allow Fail)", "no_GPL"):
+            self.assertEqual(output.count(f'group: "{group}"'), 1)
+        self.assertNotIn('group: "Build"', output)
+        self.assertNotIn('trigger: "julia-publish"', output)
+        self.assertNotIn("PUBLISH_NOGPL", output)
+
+    def test_scheduled_workloads_option_never_publishes(self):
+        output = render("--scheduled-workloads", source="schedule")
+
+        self.assertIn('group: "Source Build"', output)
+        self.assertNotIn('trigger: "julia-publish"', output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `needs full CI` label currently enables coverage, but the source, no-GPL, and other scheduled groups are only rendered for schedule builds. Add a label-gated launcher that renders those groups as a supplemental PR pipeline. Publishing remains exclusive to real schedule builds.

Put every pipeline-upload-only step on the dedicated `launch` queue so coverage and other generated jobs appear without waiting behind build or signing work. The generated workloads retain their existing queues.

After merging, the checked-in publish, publish-test, and promote webUI definitions must also be pasted into their Buildkite pipeline settings.